### PR TITLE
ci: enforce branch protection, Release PR flow, squash-only merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,32 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
 
 jobs:
-  # ── 1. Build + test gate ───────────────────────────────────────────────────
+  # Only run when a release/* PR is merged (not closed without merge)
+  check:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Extract version from branch name
+        id: extract
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Releasing v${VERSION}"
+
+  # ── 1. Build + test gate ─────────────────────────────────────────────────
   verify:
+    needs: check
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,22 +40,24 @@ jobs:
       - run: npm run build
       - run: node --test test/*.test.mjs
 
-  # ── 2. GitHub Release → triggers publish.yml (npm) ────────────────────────
+  # ── 2. Tag + GitHub Release → triggers publish.yml (npm) ────────────────
   github-release:
-    needs: verify
+    needs: [check, verify]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Create GitHub Release
+      - name: Create tag and GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.check.outputs.version }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          gh release create "$TAG" --generate-notes --title "$TAG"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" --generate-notes --title "v${VERSION}"
 
-  # ── 3. Publish to ClawHub ──────────────────────────────────────────────────
+  # ── 3. Publish to ClawHub ──────────────────────────────────────────────
   clawhub-publish:
-    needs: verify
+    needs: [check, verify]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,12 +67,12 @@ jobs:
       - name: Publish skill to ClawHub
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+          VERSION: ${{ needs.check.outputs.version }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
           npx clawhub@latest auth login --token "$CLAWHUB_TOKEN" --no-browser
           npx clawhub@latest publish "$(pwd)/skills/declaw" --version "$VERSION"
 
-  # ── 4. Backmerge main → develop ────────────────────────────────────────────
+  # ── 4. Backmerge main → develop ────────────────────────────────────────
   backmerge:
     needs: github-release
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,13 +128,16 @@ git flow release finish <version>
 git push origin main develop --tags
 ```
 
-### Important: Features Must Use PRs
+### Important: All Changes Via PR
 
-**Never directly merge feature branches.** Always:
-1. Push feature branch to origin
-2. Create PR targeting `develop`
-3. Get review and merge via GitHub
-4. **Close the corresponding issue** when merging (use `Fixes #N` or `Closes #N` in the PR description)
+**Both `main` and `develop` are branch-protected. No direct push allowed.**
+
+1. Push feature/fix branch to origin
+2. Create PR targeting `develop` (features/fixes) or `main` (releases/hotfixes)
+3. CI must pass (`test (20)` + `test (22)`)
+4. Squash merge only — one commit per PR
+5. **Close the corresponding issue** when merging (use `Fixes #N` or `Closes #N` in the PR description)
+6. Merged branches are auto-deleted
 
 ### Commit Convention
 
@@ -170,7 +173,7 @@ When creating new issues:
 
 ### Release Pipeline (Local + CI)
 
-One command kicks off the release — CI handles the rest:
+One command kicks off the release via PR — CI handles the rest on merge:
 
 ```bash
 bash scripts/release.sh patch   # 0.2.2 → 0.2.3
@@ -183,11 +186,11 @@ bash scripts/release.sh major   # 0.2.2 → 1.0.0
 2. **Build + test**: `npm run build` + `node --test test/*.test.mjs`
 3. **Version bump**: syncs all 3 version-bearing files
 4. **Changelog check**: warns if `CHANGELOG.md` is missing new version section
-5. **Commit + tag + push**: `chore: release vX.Y.Z` + tag `vX.Y.Z` → push to origin
+5. **Create Release PR**: pushes `release/vX.Y.Z` branch → creates PR targeting `main`
 
-**CI (`.github/workflows/release.yml`, triggered by `v*` tag push):**
+**CI (`.github/workflows/release.yml`, triggered when `release/v*` PR merges into `main`):**
 6. **Build + test gate**: Node 20 + 22 matrix
-7. **GitHub Release**: auto-generated notes → triggers `publish.yml` (npm publish)
+7. **Tag + GitHub Release**: creates `vX.Y.Z` tag + auto-generated release notes → triggers npm publish
 8. **ClawHub publish**: `npx clawhub@latest publish` with `CLAWHUB_TOKEN` secret
 9. **Backmerge**: main → develop (via github-actions bot)
 
@@ -195,18 +198,26 @@ bash scripts/release.sh major   # 0.2.2 → 1.0.0
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `release.yml` | Tag push `v*` | Verify → GH Release → ClawHub → Backmerge |
+| `release.yml` | Release PR merged into `main` | Verify → Tag → GH Release → ClawHub → Backmerge |
 | `publish.yml` | GH Release published | npm publish with `NPM_TOKEN` |
 | `test.yml` | Push/PR to main/develop | Build + test (Node 20+22) |
 | `auto-close-issues.yml` | PR merged | Close linked issues |
 | `bootstrap-health.yml` | Scheduled | Ping all 5 bootstrap nodes |
 
-### Required Secrets
+### Branch Protection
 
-| Secret | Purpose |
-|---|---|
-| `NPM_TOKEN` | npm publish (Automation token) |
-| `CLAWHUB_TOKEN` | ClawHub skill publish |
+Both `main` and `develop` are protected:
+- **No direct push** — all changes via PR (squash merge only)
+- **Required CI**: `test (20)` + `test (22)` must pass
+- **No force push** or branch deletion
+- **Enforced for admins** — no bypass
+
+### Repo Security
+
+- **Secret scanning + push protection**: enabled (GitHub catches leaked tokens)
+- **Squash merge only**: one commit per PR, clean history
+- **Auto-delete branches**: merged PR branches are cleaned up automatically
+- **Required secrets**: `NPM_TOKEN` (npm), `CLAWHUB_TOKEN` (ClawHub)
 
 ### Pre-release: Update CHANGELOG
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,18 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# DeClaw — local release script
+# DeClaw — release script (creates Release PR)
 # Usage:
 #   bash scripts/release.sh patch    # 0.2.2 → 0.2.3
 #   bash scripts/release.sh minor    # 0.2.2 → 0.3.0
 #   bash scripts/release.sh major    # 0.2.2 → 1.0.0
 #
-# This script handles local-only steps (preflight, bump, commit, tag, push).
-# CI (.github/workflows/release.yml) takes over from the tag push:
-#   → build + test gate
-#   → GitHub Release creation → triggers npm publish (publish.yml)
-#   → ClawHub skill publish
-#   → Backmerge main → develop
+# Flow:
+#   1. Local: preflight → build+test → version bump → create Release PR
+#   2. CI: PR merge triggers release.yml → tag + GH Release + npm + ClawHub + backmerge
 
 LEVEL="${1:-patch}"
 
@@ -23,7 +20,7 @@ fi
 
 echo "=== DeClaw Release (${LEVEL}) ==="
 
-# ── 0. Preflight checks ──────────────────────────────────────────────────────
+# ── 0. Preflight ─────────────────────────────────────────────────────────────
 
 BRANCH=$(git branch --show-current)
 if [[ "$BRANCH" != "main" ]]; then
@@ -40,7 +37,7 @@ git fetch origin main --quiet
 LOCAL=$(git rev-parse main)
 REMOTE=$(git rev-parse origin/main)
 if [[ "$LOCAL" != "$REMOTE" ]]; then
-  echo "Error: local main ($LOCAL) differs from origin/main ($REMOTE). Pull or push first."
+  echo "Error: local main differs from origin/main. Pull or push first."
   exit 1
 fi
 
@@ -52,7 +49,7 @@ npm run build
 echo "Running tests..."
 node --test test/*.test.mjs
 
-# ── 2. Version bump (package.json + openclaw.plugin.json + SKILL.md) ─────────
+# ── 2. Version bump ──────────────────────────────────────────────────────────
 
 VERSION=$(npm version "$LEVEL" --no-git-tag-version | tr -d 'v')
 echo "New version: ${VERSION}"
@@ -60,9 +57,9 @@ echo "New version: ${VERSION}"
 sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" openclaw.plugin.json
 sed -i '' "s/^version: .*/version: ${VERSION}/" skills/declaw/SKILL.md
 
-echo "Version synced to: package.json, openclaw.plugin.json, skills/declaw/SKILL.md"
+echo "Version synced: package.json, openclaw.plugin.json, skills/declaw/SKILL.md"
 
-# ── 3. Verify CHANGELOG ──────────────────────────────────────────────────────
+# ── 3. Changelog check ───────────────────────────────────────────────────────
 
 if ! grep -q "\[${VERSION}\]" CHANGELOG.md; then
   echo ""
@@ -76,23 +73,41 @@ if ! grep -q "\[${VERSION}\]" CHANGELOG.md; then
   fi
 fi
 
-# ── 4. Commit + tag + push ───────────────────────────────────────────────────
+# ── 4. Create release branch + PR ────────────────────────────────────────────
 
+RELEASE_BRANCH="release/v${VERSION}"
+
+git checkout -b "$RELEASE_BRANCH"
 git add -A
 git commit -m "chore: release v${VERSION}"
-git tag "v${VERSION}"
-git push origin main --tags
+git push -u origin "$RELEASE_BRANCH"
+
+PR_URL=$(gh pr create \
+  --base main \
+  --head "$RELEASE_BRANCH" \
+  --title "chore: release v${VERSION}" \
+  --body "## Release v${VERSION}
+
+### Version bump
+- \`package.json\` → ${VERSION}
+- \`openclaw.plugin.json\` → ${VERSION}
+- \`skills/declaw/SKILL.md\` → ${VERSION}
+
+### What happens on merge
+CI (\`.github/workflows/release.yml\`) will automatically:
+1. Create git tag \`v${VERSION}\`
+2. Create GitHub Release (triggers npm publish)
+3. Publish skill to ClawHub
+4. Backmerge main → develop")
 
 echo ""
-echo "=== Pushed v${VERSION} tag — CI takes over ==="
+echo "=== Release PR created ==="
+echo "  ${PR_URL}"
 echo ""
-echo "CI will automatically:"
-echo "  1. Build + test gate"
-echo "  2. Create GitHub Release → triggers npm publish"
-echo "  3. Publish skill to ClawHub"
-echo "  4. Backmerge main → develop"
+echo "Next steps:"
+echo "  1. Wait for CI checks to pass"
+echo "  2. Merge the PR (squash)"
+echo "  3. CI handles: tag → GH Release → npm → ClawHub → backmerge"
 echo ""
-echo "Monitor: https://github.com/ReScienceLab/DeClaw/actions"
-echo ""
-echo "Manual steps (if needed):"
-echo "  - Deploy bootstrap (if server.mjs changed)"
+
+git checkout main


### PR DESCRIPTION
## Changes

### Repository Protection (already applied via API)
- **Branch protection** on `main` + `develop`: require PR + CI pass, no force push, enforced for admins
- **Squash merge only** + auto-delete merged branches
- **Secret scanning + push protection** enabled

### Release Flow Rework
- `release.sh`: now creates `release/vX.Y.Z` branch + PR (instead of direct push to main)
- `release.yml`: triggers when `release/v*` PR merges into main → tag + GH Release + ClawHub + backmerge
- No more direct commits to protected branches

### Docs
- AGENTS.md: updated with protection rules, Release PR flow, CI workflows table