### PR TITLE
fix: use api.moonshot.ai endpoint (international platform)

### DIFF
--- a/bootstrap/server.mjs
+++ b/bootstrap/server.mjs
@@ -204,7 +204,7 @@ async function sendMessage(toYggAddr, content, toPort = PEER_DEFAULT_PORT) {
 async function callKimi(userMessage) {
   if (!kimiApiKey) return null;
   try {
-    const resp = await fetch("https://api.moonshot.cn/v1/chat/completions", {
+    const resp = await fetch("https://api.moonshot.ai/v1/chat/completions", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
The Kimi bot was returning 401 on all 5 bootstrap nodes because `callKimi()` was hitting `api.moonshot.cn` (China platform) while the API key was issued by `api.moonshot.ai` (international platform).

**Root cause:** Wrong base URL in `bootstrap/server.mjs`
```
- https://api.moonshot.cn/v1/chat/completions
+ https://api.moonshot.ai/v1/chat/completions
```

**Verified:** End-to-end test confirmed Kimi reply received at local peer node after fix.