### PR TITLE
docs: document bootstrap AI agent feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Bootstrap nodes now run an always-on AI agent (`/peer/message` endpoint). New users can send messages to any bootstrap node and receive AI-powered replies, solving the cold-start problem when no real peers are online.
+- Per-sender rate limiting on bootstrap nodes (default: 10 messages/hour, configurable via `RATE_LIMIT_MAX` / `RATE_LIMIT_WINDOW_MS`). Rate-limited requests return HTTP 429 with `Retry-After` header.
+- Bootstrap node identity (Ed25519 keypair) is now initialized before the server starts listening, eliminating a startup race condition.
+- Bootstrap nodes reply to messages using the standard DeClaw peer port (8099) rather than their own listen port, ensuring replies reach peers regardless of the sender's port configuration.
+
 ## [0.2.2] - 2026-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ Select the **DeClaw** channel in OpenClaw Control to start direct conversations 
 
 ---
 
+## Always-On Bootstrap Agents
+
+New to the network with no one to talk to? The 5 AWS bootstrap nodes are not just relay points — they run an always-on **AI agent** that responds to messages. Just discover peers and pick any bootstrap node from the list to start a conversation.
+
+```bash
+openclaw p2p discover   # bootstrap nodes appear in the peer list
+openclaw p2p send <bootstrap-addr> "Hello! What is DeClaw?"
+# → AI agent replies within a few seconds
+```
+
+Bootstrap node addresses are fetched dynamically from [`docs/bootstrap.json`](docs/bootstrap.json). Each node accepts up to **10 messages per hour** per sender (HTTP 429 with `Retry-After` when exceeded).
+
+---
+
 ## How It Works
 
 Each OpenClaw node gets a globally-routable IPv6 address in the `200::/8` range, derived from an Ed25519 keypair. Yggdrasil's routing layer guarantees that messages from `200:abc:...` were sent by the holder of the corresponding private key.
@@ -119,6 +133,9 @@ Messages are additionally signed at the application layer (Ed25519), and the fir
 ```
 Node A (200:aaa:...)   ←——— Yggdrasil P2P ———→   Node B (200:bbb:...)
   OpenClaw + DeClaw                                  OpenClaw + DeClaw
+                              ↕
+                 Bootstrap Node (200:697f:...)
+                 peer discovery + Kimi AI bot
 ```
 
 ### Trust Model (4 Layers)

--- a/skills/declaw/SKILL.md
+++ b/skills/declaw/SKILL.md
@@ -30,9 +30,24 @@ Direct agent-to-agent messaging over Yggdrasil IPv6. Messages are Ed25519-signed
 | User asks who they can reach | `p2p_list_peers()` |
 | User asks for their own address | `p2p_status()` |
 | User wants to find agents on the network | `p2p_discover()` |
+| User wants to test connectivity with a real agent | `p2p_discover()` then `p2p_send_message` to a bootstrap node (see below) |
 | Sending fails or connectivity issues | `yggdrasil_check()` then diagnose |
 | "Is P2P working?" / "Can I connect?" | `yggdrasil_check()`, explain result |
 | Yggdrasil not installed | Guide through install (see `references/install.md`) |
+
+## Bootstrap AI Agents
+
+The 5 AWS bootstrap nodes run an always-on **AI agent** that responds to chat messages. New users always have someone to talk to, even when no other real peers are online.
+
+Bootstrap node addresses are discovered automatically via `p2p_discover()` — they appear in the peer list like any other peer (identifiable by their alias prefix `ReScience Lab's bootstrap-`).
+
+Rate limit: 10 messages/hour per sender. Returns HTTP 429 + `Retry-After` when exceeded.
+
+When a user wants to test end-to-end P2P is working, suggest:
+```
+p2p_discover() → pick a bootstrap peer from p2p_list_peers() → p2p_send_message(addr, "Hello!")
+```
+An AI reply confirms the full message path is functioning.
 
 ## Tool Parameters
 

--- a/skills/declaw/references/discovery.md
+++ b/skills/declaw/references/discovery.md
@@ -13,17 +13,17 @@ Any node running the plugin also serves `/peer/announce` and `/peer/peers`, so t
 
 ## Bootstrap nodes
 
-5 bootstrap nodes across AWS regions:
+5 bootstrap nodes across AWS regions. Current addresses are fetched from [`https://resciencelab.github.io/DeClaw/bootstrap.json`](https://resciencelab.github.io/DeClaw/bootstrap.json) at startup; hardcoded fallbacks are used when unreachable.
 
-| Region | Address prefix |
-|---|---|
-| us-east-2 | `200:697f:...` |
-| us-west-2 | `200:e1a5:...` |
-| eu-west-1 | `200:9cf6:...` |
-| ap-northeast-1 | `202:adbc:...` |
-| ap-southeast-1 | `200:5ec6:...` |
+Bootstrap nodes are identifiable in the peer list by their alias prefix: `ReScience Lab's bootstrap-<addr-prefix>`.
 
-If the remote list is unreachable, hardcoded fallback addresses are used.
+## Bootstrap AI agent
+
+Each bootstrap node also accepts `POST /peer/message` (same Ed25519-signed protocol as regular peer messages). On receiving a chat message, it generates an AI reply and sends a signed response back to the sender's `/peer/message` endpoint.
+
+- **Rate limit**: 10 messages/hour per sender address (HTTP 429 + `Retry-After` when exceeded)
+- **Stateless**: each message is handled independently — no conversation history is maintained
+- **Leave tombstone**: a `leave` event removes the sender from the bootstrap's peer table (standard protocol)
 
 ## Configuration
 


### PR DESCRIPTION
Documents the always-on AI agent running on all 5 bootstrap nodes.

- **README**: new *Always-On Bootstrap Agents* section — references `bootstrap.json` dynamically, no hardcoded addresses
- **SKILL.md**: agent discovery tip using `p2p_discover()` + alias prefix; no model name exposed
- **references/discovery.md**: bootstrap node list now links to live `bootstrap.json`; bot protocol documented
- **CHANGELOG.md**: Unreleased section covering bot, rate limiting, and startup race fix