### PR TITLE
fix: update Yggdrasil apt repo to S3 (old GitHub Pages key is 404)

### DIFF
--- a/.github/workflows/bootstrap-health.yml
+++ b/.github/workflows/bootstrap-health.yml
@@ -15,8 +15,10 @@ jobs:
 
       - name: Install Yggdrasil
         run: |
-          curl -fsSL https://www.yggdrasil-network.github.io/apt-key.gpg | sudo apt-key add -
-          echo "deb http://www.yggdrasil-network.github.io/apt/ debian main" \
+          sudo mkdir -p /usr/local/apt-keys
+          gpg --fetch-keys https://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/key.txt
+          gpg --export 1C5162E133015D81A811239D1840CDAC6011C5EA | sudo tee /usr/local/apt-keys/yggdrasil-keyring.gpg > /dev/null
+          echo 'deb [signed-by=/usr/local/apt-keys/yggdrasil-keyring.gpg] http://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/ debian yggdrasil' \
             | sudo tee /etc/apt/sources.list.d/yggdrasil.list
           sudo apt-get update -qq
           sudo apt-get install -y -qq yggdrasil

--- a/skills/declaw/references/install.md
+++ b/skills/declaw/references/install.md
@@ -40,10 +40,12 @@ Run `openclaw p2p setup` instead.
 ### Linux — Debian / Ubuntu
 
 ```bash
-curl -sL https://www.yggdrasil-network.github.io/apt-key.gpg | sudo apt-key add -
-echo "deb http://www.yggdrasil-network.github.io/apt/ debian main" \
+sudo mkdir -p /usr/local/apt-keys
+gpg --fetch-keys https://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/key.txt
+gpg --export 1C5162E133015D81A811239D1840CDAC6011C5EA | sudo tee /usr/local/apt-keys/yggdrasil-keyring.gpg > /dev/null
+echo 'deb [signed-by=/usr/local/apt-keys/yggdrasil-keyring.gpg] http://neilalexander.s3.dualstack.eu-west-2.amazonaws.com/deb/ debian yggdrasil' \
   | sudo tee /etc/apt/sources.list.d/yggdrasil.list
-sudo apt update && sudo apt install yggdrasil
+sudo apt-get update && sudo apt-get install yggdrasil
 ```
 
 ### Linux — Arch


### PR DESCRIPTION
Cherry-pick of #27. The old Yggdrasil GitHub Pages apt key URL returns 404, breaking bootstrap-health CI. Updated to official S3 repo with new GPG key.