### PR TITLE
docs: remove remaining Git Flow / develop references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,9 +89,7 @@ All runtime config is in `openclaw.json` under `plugins.entries.declaw.config`:
 
 ## Git Workflow
 
-We use **Git Flow** for version control. Install with `brew install git-flow`.
-
-### Branching Strategy (Git Flow)
+### Branching Strategy
 
 - `main` — The only long-lived branch, always deployable
 - `feature/<slug>` — New features (branch from `main`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,24 +50,29 @@ Look for issues labeled [`good first issue`](https://github.com/ReScienceLab/DeC
 
 ### Submitting Code
 
-1. Fork the repo and create a branch from `develop`:
+1. Fork the repo and create a branch from `main`:
    ```bash
-   git checkout develop
+   git checkout main
    git checkout -b feature/your-feature
    ```
 
 2. Make your changes, following the conventions below
 
-3. Build and test:
+3. Add a changeset describing what changed:
+   ```bash
+   npx changeset add
+   ```
+
+4. Build and test:
    ```bash
    npm run build
    node --test test/*.test.mjs
    ```
 
-4. Push and create a PR targeting `develop`:
+5. Push and create a PR targeting `main`:
    ```bash
    git push -u origin feature/your-feature
-   gh pr create --base develop
+   gh pr create --base main
    ```
 
 5. Wait for CI (Node 20+22 test matrix) to pass. All PRs are squash-merged.


### PR DESCRIPTION
Closes stray Git Flow artifacts found during post-migration structure review.

## Changes
- `CONTRIBUTING.md`: update fork+PR flow to target `main`, add `npx changeset add` step
- `AGENTS.md`: remove 'We use Git Flow' header and `brew install git-flow` instruction

No code changes. All 44 tests pass.