### PR TITLE
ci: add changeset PR check

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,38 @@
+name: Changeset Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+jobs:
+  check:
+    name: Changeset present
+    runs-on: ubuntu-latest
+    # Skip the "Version Packages" PR that changesets/action creates
+    if: |
+      github.actor != 'github-actions[bot]' &&
+      !startsWith(github.head_ref, 'changeset-release/')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changeset or skip-changelog label
+        run: |
+          if echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | grep -q '"skip-changelog"'; then
+            echo "skip-changelog label present — no changeset required."
+            exit 0
+          fi
+
+          if git diff --name-only origin/main...HEAD | grep -qE '^\.changeset/.+\.md$'; then
+            echo "Changeset found."
+            exit 0
+          fi
+
+          echo ""
+          echo "No changeset found."
+          echo ""
+          echo "Run 'npx changeset add', select patch/minor/major, write one line, and commit the result."
+          echo "If this PR does not need a version bump (e.g. docs, CI, tests), add the 'skip-changelog' label."
+          exit 1


### PR DESCRIPTION
Adds a required status check that enforces every contributor PR includes a changeset file.

## Behaviour
- Fails if no `.changeset/*.md` was added/modified in the PR
- Passes if the `skip-changelog` label is present (for docs/CI/test-only PRs)
- Automatically skips the Version Packages PR that `changesets/action` creates

## Next step
After this merges, `Changeset present` will be added as a required status check in branch protection.