### PR TITLE
fix: patch clawhub publish to include acceptLicenseTerms

### DIFF
--- a/.changeset/fix-clawhub-license.md
+++ b/.changeset/fix-clawhub-license.md
@@ -1,0 +1,5 @@
+---
+"@resciencelab/declaw": patch
+---
+
+Fix clawhub publish by patching acceptLicenseTerms into publish payload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,9 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           npx clawhub@latest auth login --token "$CLAWHUB_TOKEN" --no-browser
+          # Patch clawhub publish.js to include acceptLicenseTerms (required by API, missing in CLI v0.7.0)
+          PUBLISH_JS=$(find ~/.npm/_npx -path "*/clawhub/dist/cli/commands/publish.js" 2>/dev/null | head -1)
+          if [ -n "$PUBLISH_JS" ]; then
+            sed -i '/tags,/a\            acceptLicenseTerms: true,' "$PUBLISH_JS"
+          fi
           npx clawhub@latest publish "$(pwd)/skills/declaw" --version "$VERSION"


### PR DESCRIPTION
## Problem

ClawHub API now requires `acceptLicenseTerms: true` in the publish payload, but `clawhub` CLI v0.7.0 (latest) doesn't send it. This causes `Publish payload: acceptLicenseTerms: invalid value` on every release.

## Fix

After `npx clawhub@latest` installs the CLI, patch `publish.js` in the npx cache to inject `acceptLicenseTerms: true` into the form payload before calling `clawhub publish`.

This is a temporary workaround until clawhub CLI is updated to include this field.