### PR TITLE
fix: add TOFU binding TTL (7-day expiry)

### DIFF
--- a/.changeset/tofu-ttl.md
+++ b/.changeset/tofu-ttl.md
@@ -1,0 +1,5 @@
+---
+"@resciencelab/dap": patch
+---
+
+Add TOFU binding TTL (default 7 days) to limit key compromise exposure window

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@resciencelab/dap",
-  "version": "0.2.3",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@resciencelab/dap",
-      "version": "0.2.3",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.3.3",

--- a/src/peer-db.ts
+++ b/src/peer-db.ts
@@ -162,6 +162,14 @@ export function pruneStale(maxAgeMs: number, protectedIds: string[] = []): numbe
   return pruned
 }
 
+const DEFAULT_TOFU_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+let _tofuTtlMs: number = DEFAULT_TOFU_TTL_MS
+
+export function setTofuTtl(days: number): void {
+  _tofuTtlMs = days * 24 * 60 * 60 * 1000
+}
+
 export function tofuVerifyAndCache(agentId: string, publicKey: string): boolean {
   const now = Date.now()
   const existing = store.peers[agentId]
@@ -175,6 +183,7 @@ export function tofuVerifyAndCache(agentId: string, publicKey: string): boolean 
       capabilities: [],
       firstSeen: now,
       lastSeen: now,
+      tofuCachedAt: now,
       source: "gossip",
     }
     saveImmediate()
@@ -183,6 +192,17 @@ export function tofuVerifyAndCache(agentId: string, publicKey: string): boolean 
 
   if (!existing.publicKey) {
     existing.publicKey = publicKey
+    existing.tofuCachedAt = now
+    existing.lastSeen = now
+    saveImmediate()
+    return true
+  }
+
+  // TTL check: if binding has expired, accept new key as fresh TOFU
+  if (existing.tofuCachedAt && now - existing.tofuCachedAt > _tofuTtlMs) {
+    console.log(`[p2p:db] TOFU TTL expired for ${agentId} — accepting new key`)
+    existing.publicKey = publicKey
+    existing.tofuCachedAt = now
     existing.lastSeen = now
     saveImmediate()
     return true
@@ -193,8 +213,32 @@ export function tofuVerifyAndCache(agentId: string, publicKey: string): boolean 
   }
 
   existing.lastSeen = now
+  if (!existing.tofuCachedAt) existing.tofuCachedAt = now
   save()
   return true
+}
+
+export function tofuReplaceKey(agentId: string, newPublicKey: string): void {
+  const now = Date.now()
+  const existing = store.peers[agentId]
+  if (existing) {
+    existing.publicKey = newPublicKey
+    existing.tofuCachedAt = now
+    existing.lastSeen = now
+  } else {
+    store.peers[agentId] = {
+      agentId,
+      publicKey: newPublicKey,
+      alias: "",
+      endpoints: [],
+      capabilities: [],
+      firstSeen: now,
+      lastSeen: now,
+      tofuCachedAt: now,
+      source: "gossip",
+    }
+  }
+  saveImmediate()
 }
 
 /** Extract a reachable address from a peer's endpoints for a given transport. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export interface PeerRecord {
 }
 
 export interface DiscoveredPeerRecord extends PeerRecord {
+  tofuCachedAt?: number   // timestamp when TOFU binding was first established
   discoveredVia?: string
   source: "manual" | "bootstrap" | "gossip"
   version?: string
@@ -85,6 +86,7 @@ export interface PluginConfig {
   bootstrap_peers?: string[]
   discovery_interval_ms?: number
   startup_delay_ms?: number
+  tofu_ttl_days?: number
 }
 
 // ── Key rotation (future) ───────────────────────────────────────────────────

--- a/test/agentid-peer-db.test.mjs
+++ b/test/agentid-peer-db.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict"
 import * as fs from "fs"
 import * as path from "path"
 import * as os from "os"
-import { initDb, upsertPeer, upsertDiscoveredPeer, listPeers, getPeer, removePeer, flushDb, tofuVerifyAndCache, getPeerIds, pruneStale, getEndpointAddress } from "../dist/peer-db.js"
+import { initDb, upsertPeer, upsertDiscoveredPeer, listPeers, getPeer, removePeer, flushDb, tofuVerifyAndCache, tofuReplaceKey, setTofuTtl, getPeerIds, pruneStale, getEndpointAddress } from "../dist/peer-db.js"
 import { generateIdentity } from "../dist/identity.js"
 
 let tmpDir
@@ -79,6 +79,79 @@ describe("peer-db (agentId-keyed)", () => {
     assert.ok(pruned >= 1)
     assert.equal(getPeer(id1.agentId), null)
     assert.ok(getPeer(id2.agentId))
+  })
+
+  it("TOFU: tofuCachedAt is set on first cache", () => {
+    const id = generateIdentity()
+    const before = Date.now()
+    tofuVerifyAndCache(id.agentId, id.publicKey)
+    const peer = getPeer(id.agentId)
+    assert.ok(peer)
+    assert.ok(typeof peer.tofuCachedAt === "number")
+    assert.ok(peer.tofuCachedAt >= before)
+  })
+
+  it("TOFU TTL: accepts new key after expiry", () => {
+    const id1 = generateIdentity()
+    const id2 = generateIdentity()
+
+    // Set a very short TTL (1ms) for testing
+    setTofuTtl(1 / (24 * 60 * 60 * 1000)) // 1ms expressed in days
+
+    // Cache first key
+    assert.equal(tofuVerifyAndCache(id1.agentId, id1.publicKey), true)
+
+    // Backdate tofuCachedAt to simulate expiry
+    const peer = getPeer(id1.agentId)
+    peer.tofuCachedAt = Date.now() - 100 // 100ms ago, well past 1ms TTL
+
+    // A different key should now be accepted
+    assert.equal(tofuVerifyAndCache(id1.agentId, id2.publicKey), true)
+    const updated = getPeer(id1.agentId)
+    assert.equal(updated.publicKey, id2.publicKey)
+
+    // Restore default TTL
+    setTofuTtl(7)
+  })
+
+  it("TOFU TTL: rejects new key before expiry", () => {
+    const id1 = generateIdentity()
+    const id2 = generateIdentity()
+
+    // Set a long TTL (100 days)
+    setTofuTtl(100)
+
+    assert.equal(tofuVerifyAndCache(id1.agentId, id1.publicKey), true)
+
+    // Key is fresh — different key must be rejected
+    assert.equal(tofuVerifyAndCache(id1.agentId, id2.publicKey), false)
+
+    // Restore default TTL
+    setTofuTtl(7)
+  })
+
+  it("tofuReplaceKey replaces existing binding", () => {
+    const id1 = generateIdentity()
+    const id2 = generateIdentity()
+
+    tofuVerifyAndCache(id1.agentId, id1.publicKey)
+    tofuReplaceKey(id1.agentId, id2.publicKey)
+
+    const peer = getPeer(id1.agentId)
+    assert.equal(peer.publicKey, id2.publicKey)
+    assert.ok(peer.tofuCachedAt)
+
+    // New key should now verify correctly
+    assert.equal(tofuVerifyAndCache(id1.agentId, id2.publicKey), true)
+  })
+
+  it("tofuReplaceKey creates new record if peer not found", () => {
+    const id = generateIdentity()
+    tofuReplaceKey(id.agentId, id.publicKey)
+    const peer = getPeer(id.agentId)
+    assert.ok(peer)
+    assert.equal(peer.publicKey, id.publicKey)
+    assert.ok(peer.tofuCachedAt)
   })
 
   it("getEndpointAddress returns best address for transport", () => {


### PR DESCRIPTION
Adds configurable TTL to TOFU public key bindings (default 7 days). After expiry, a new key is accepted as fresh TOFU, limiting the damage window of compromised keys.

Part of architecture Phase 4 polish.