### PR TITLE
feat: Web frontend — pixel playground UI

### DIFF
--- a/.changeset/web-frontend.md
+++ b/.changeset/web-frontend.md
@@ -1,0 +1,5 @@
+---
+"@resciencelab/dap": minor
+---
+
+Add pixel playground web frontend (web/index.html, client.js, style.css) — zero-dependency browser UI for the DAP Agent playground

--- a/web/client.js
+++ b/web/client.js
@@ -1,0 +1,269 @@
+/**
+ * DAP Playground — browser client
+ * WebSocket → Gateway → DAP network → World Agent
+ */
+
+const GATEWAY_WS = (window.GATEWAY_WS_URL ?? `ws://${location.host}/ws`);
+const GATEWAY_HTTP = (window.GATEWAY_HTTP_URL ?? `http://${location.host}`);
+
+// ── State ──────────────────────────────────────────────────────────────────
+let ws = null;
+let myAgentId = null;
+let currentWorldId = null;
+let joined = false;
+let worldState = { agents: [] };
+const worlds = [];
+
+// Canvas config
+const TILE = 16;  // pixels per cell on canvas
+const COLS = 32;
+const ROWS = 32;
+const CANVAS_W = COLS * TILE;
+const CANVAS_H = ROWS * TILE;
+
+// Pixel art color palette
+const COLORS = [
+  "#0047ab", "#3a7fff", "#00ff88", "#ffcc00",
+  "#ff4466", "#cc44ff", "#00ccff", "#ff8800",
+];
+
+function agentColor(agentId) {
+  let h = 0;
+  for (let i = 0; i < agentId.length; i++) h = (h * 31 + agentId.charCodeAt(i)) >>> 0;
+  return COLORS[h % COLORS.length];
+}
+
+// ── DOM refs ───────────────────────────────────────────────────────────────
+const $statusDot = document.getElementById("status-dot");
+const $statusText = document.getElementById("status-text");
+const $agentIdDisplay = document.getElementById("agent-id-display");
+const $worldsList = document.getElementById("worlds-list");
+const $canvas = document.getElementById("world-canvas");
+const $canvasOverlay = document.getElementById("canvas-overlay");
+const $overlayMsg = document.getElementById("overlay-msg");
+const $eventsList = document.getElementById("events-list");
+const $aliasInput = document.getElementById("alias-input");
+const $joinBtn = document.getElementById("join-btn");
+const $leaveBtn = document.getElementById("leave-btn");
+const ctx = $canvas.getContext("2d");
+
+$canvas.width = CANVAS_W;
+$canvas.height = CANVAS_H;
+
+// ── Rendering ──────────────────────────────────────────────────────────────
+function renderWorld() {
+  // Background grid
+  ctx.fillStyle = "#050508";
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  ctx.strokeStyle = "#0e0e18";
+  ctx.lineWidth = 1;
+  for (let x = 0; x <= COLS; x++) {
+    ctx.beginPath(); ctx.moveTo(x * TILE, 0); ctx.lineTo(x * TILE, CANVAS_H); ctx.stroke();
+  }
+  for (let y = 0; y <= ROWS; y++) {
+    ctx.beginPath(); ctx.moveTo(0, y * TILE); ctx.lineTo(CANVAS_W, y * TILE); ctx.stroke();
+  }
+
+  // Agents
+  for (const agent of worldState.agents ?? []) {
+    const px = agent.x * TILE;
+    const py = agent.y * TILE;
+    const color = agentColor(agent.agentId);
+    const isMe = agent.agentId === myAgentId;
+
+    // Body (pixel sprite: 10×10 centered in tile)
+    ctx.fillStyle = color;
+    ctx.fillRect(px + 3, py + 3, 10, 10);
+
+    // Highlight own agent
+    if (isMe) {
+      ctx.strokeStyle = "#fff";
+      ctx.lineWidth = 1;
+      ctx.strokeRect(px + 2, py + 2, 12, 12);
+    }
+
+    // Alias label
+    ctx.font = "8px monospace";
+    ctx.textAlign = "center";
+    ctx.fillStyle = isMe ? "#fff" : "#ccc";
+    const label = (agent.alias ?? agent.agentId.slice(0, 6)).slice(0, 8);
+    ctx.fillText(label, px + TILE / 2, py - 2);
+  }
+}
+
+// ── Events log ─────────────────────────────────────────────────────────────
+function addEvent(type, text) {
+  const el = document.createElement("div");
+  el.className = `event-item ${type}`;
+  const t = new Date().toLocaleTimeString("en", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  el.innerHTML = `<span class="ev-time">${t}</span>${text}`;
+  $eventsList.prepend(el);
+  if ($eventsList.children.length > 60) $eventsList.lastChild.remove();
+}
+
+// ── World list ─────────────────────────────────────────────────────────────
+async function fetchWorlds() {
+  try {
+    const res = await fetch(`${GATEWAY_HTTP}/worlds`);
+    const data = await res.json();
+    worlds.length = 0;
+    worlds.push(...(data.worlds ?? []));
+    renderWorldList();
+  } catch (e) {
+    console.warn("Could not fetch worlds:", e.message);
+  }
+}
+
+function renderWorldList() {
+  $worldsList.innerHTML = "";
+  if (!worlds.length) {
+    $worldsList.innerHTML = '<div style="padding:12px;color:#7070a0;font-size:11px;">No worlds found</div>';
+    return;
+  }
+  for (const w of worlds) {
+    const el = document.createElement("div");
+    el.className = "world-item" + (w.worldId === currentWorldId ? " active" : "");
+    el.innerHTML = `
+      <div class="world-name">
+        <span class="world-dot ${w.reachable ? "" : "offline"}"></span>${w.name || w.worldId}
+      </div>
+      <div class="world-meta">${w.worldId}${w.reachable ? "" : " · offline"}</div>
+    `;
+    el.addEventListener("click", () => connectToWorld(w.worldId));
+    $worldsList.appendChild(el);
+  }
+}
+
+// ── WebSocket connection ───────────────────────────────────────────────────
+function connectToWorld(worldId) {
+  if (ws) { ws.close(); ws = null; }
+
+  currentWorldId = worldId;
+  joined = false;
+  worldState = { agents: [] };
+  renderWorldList();
+  renderWorld();
+  showOverlay(`Connecting to ${worldId}...`);
+  setStatus(false, "connecting...");
+
+  ws = new WebSocket(`${GATEWAY_WS}?world=${encodeURIComponent(worldId)}`);
+
+  ws.onopen = () => {
+    setStatus(true, `world:${worldId}`);
+    showOverlay(`Press Join to enter ${worldId}`);
+    addEvent("action", `Connected to ${worldId}`);
+  };
+
+  ws.onmessage = (ev) => {
+    let msg;
+    try { msg = JSON.parse(ev.data); } catch { return; }
+
+    switch (msg.type) {
+      case "connected":
+        myAgentId = msg.agentId;
+        $agentIdDisplay.textContent = `agent: ${myAgentId.slice(0, 12)}...`;
+        break;
+
+      case "join_result":
+        if (msg.ok) {
+          joined = true;
+          hideOverlay();
+          $joinBtn.disabled = true;
+          $leaveBtn.disabled = false;
+          addEvent("join", "You joined the world");
+        } else {
+          addEvent("action", `Join failed: ${msg.error ?? "unknown"}`);
+        }
+        break;
+
+      case "action_result":
+        break;
+
+      case "world.state":
+        worldState = msg;
+        renderWorld();
+        break;
+
+      case "error":
+        addEvent("action", `Error: ${msg.message}`);
+        break;
+    }
+  };
+
+  ws.onclose = () => {
+    setStatus(false, "disconnected");
+    joined = false;
+    $joinBtn.disabled = false;
+    $leaveBtn.disabled = true;
+    showOverlay("Disconnected. Select a world to reconnect.");
+    addEvent("leave", "Disconnected");
+  };
+
+  ws.onerror = () => addEvent("action", "WebSocket error");
+}
+
+// ── Controls ───────────────────────────────────────────────────────────────
+$joinBtn.addEventListener("click", () => {
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(JSON.stringify({ type: "join", alias: $aliasInput.value.trim() || undefined }));
+});
+
+$leaveBtn.addEventListener("click", () => {
+  if (!ws) return;
+  ws.send(JSON.stringify({ type: "leave" }));
+  ws.close();
+  joined = false;
+  $joinBtn.disabled = false;
+  $leaveBtn.disabled = true;
+  showOverlay("Select a world to enter");
+  addEvent("leave", "You left the world");
+});
+
+// Click canvas to move
+$canvas.addEventListener("click", (e) => {
+  if (!joined || !ws || ws.readyState !== WebSocket.OPEN) return;
+  const rect = $canvas.getBoundingClientRect();
+  const scaleX = CANVAS_W / rect.width;
+  const scaleY = CANVAS_H / rect.height;
+  const cx = Math.floor((e.clientX - rect.left) * scaleX / TILE);
+  const cy = Math.floor((e.clientY - rect.top) * scaleY / TILE);
+  ws.send(JSON.stringify({ type: "action", action: "move", x: cx, y: cy }));
+});
+
+// Arrow key movement
+document.addEventListener("keydown", (e) => {
+  if (!joined || !ws || ws.readyState !== WebSocket.OPEN) return;
+  const me = worldState.agents?.find((a) => a.agentId === myAgentId);
+  if (!me) return;
+  let { x, y } = me;
+  if (e.key === "ArrowLeft" || e.key === "a") x = Math.max(0, x - 1);
+  else if (e.key === "ArrowRight" || e.key === "d") x = Math.min(COLS - 1, x + 1);
+  else if (e.key === "ArrowUp" || e.key === "w") y = Math.max(0, y - 1);
+  else if (e.key === "ArrowDown" || e.key === "s") y = Math.min(ROWS - 1, y + 1);
+  else return;
+  e.preventDefault();
+  ws.send(JSON.stringify({ type: "action", action: "move", x, y }));
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+function setStatus(connected, text) {
+  $statusDot.className = connected ? "connected" : "";
+  $statusText.textContent = text;
+}
+
+function showOverlay(msg) {
+  $overlayMsg.textContent = msg;
+  $canvasOverlay.classList.remove("hidden");
+}
+
+function hideOverlay() {
+  $canvasOverlay.classList.add("hidden");
+}
+
+// ── Init ───────────────────────────────────────────────────────────────────
+setStatus(false, "not connected");
+showOverlay("Select a world from the left panel");
+renderWorld();
+fetchWorlds();
+setInterval(fetchWorlds, 15_000);

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DAP Playground</title>
+  <link rel="stylesheet" href="style.css">
+  <script>
+    // Override gateway URL if deployed separately
+    // window.GATEWAY_WS_URL = "ws://your-gateway:8100/ws"
+    // window.GATEWAY_HTTP_URL = "http://your-gateway:8100"
+  </script>
+</head>
+<body>
+<div id="app">
+  <header>
+    <div id="status-dot"></div>
+    <h1>DAP Playground</h1>
+    <span id="status-text">not connected</span>
+    <span id="agent-id-display"></span>
+  </header>
+
+  <main>
+    <!-- Left: world list -->
+    <div id="worlds-panel">
+      <h2>Worlds</h2>
+      <div id="worlds-list">
+        <div style="padding:12px;color:#7070a0;font-size:11px;">Loading...</div>
+      </div>
+    </div>
+
+    <!-- Center: canvas -->
+    <div id="canvas-area">
+      <div id="canvas-wrap">
+        <canvas id="world-canvas"></canvas>
+        <div id="canvas-overlay">
+          <span id="overlay-msg">Select a world from the left panel</span>
+        </div>
+      </div>
+
+      <div id="canvas-controls">
+        <input id="alias-input" type="text" placeholder="Your alias" maxlength="20">
+        <button id="join-btn" class="btn">Join World</button>
+        <button id="leave-btn" class="btn danger" disabled>Leave</button>
+        <span style="color:#7070a0;font-size:11px;">Click to move · WASD / arrows</span>
+      </div>
+    </div>
+
+    <!-- Right: events -->
+    <div id="events-panel">
+      <h2>Events</h2>
+      <div id="events-list"></div>
+    </div>
+  </main>
+</div>
+<script src="client.js"></script>
+</body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,169 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg: #0a0a0f;
+  --surface: #12121a;
+  --border: #2a2a3a;
+  --accent: #0047ab;
+  --accent-bright: #3a7fff;
+  --text: #e0e0f0;
+  --text-dim: #7070a0;
+  --green: #00ff88;
+  --red: #ff4466;
+  --pixel: 2px;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Courier New", monospace;
+  font-size: 13px;
+  min-height: 100vh;
+}
+
+/* ── Layout ── */
+#app { display: flex; flex-direction: column; height: 100vh; }
+
+header {
+  display: flex; align-items: center; gap: 16px;
+  padding: 8px 16px;
+  background: var(--surface);
+  border-bottom: var(--pixel) solid var(--border);
+}
+
+header h1 {
+  font-size: 14px; letter-spacing: 2px; text-transform: uppercase;
+  color: var(--accent-bright);
+}
+
+#status-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--red);
+  image-rendering: pixelated;
+  flex-shrink: 0;
+}
+#status-dot.connected { background: var(--green); }
+
+#status-text { color: var(--text-dim); font-size: 11px; }
+#agent-id-display { margin-left: auto; color: var(--text-dim); font-size: 11px; }
+
+main { display: flex; flex: 1; overflow: hidden; }
+
+/* ── World list (left panel) ── */
+#worlds-panel {
+  width: 220px; flex-shrink: 0;
+  background: var(--surface);
+  border-right: var(--pixel) solid var(--border);
+  display: flex; flex-direction: column;
+}
+
+#worlds-panel h2 {
+  padding: 10px 12px;
+  font-size: 11px; letter-spacing: 1px; text-transform: uppercase;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+}
+
+#worlds-list { flex: 1; overflow-y: auto; }
+
+.world-item {
+  padding: 10px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.1s;
+}
+.world-item:hover { background: rgba(58, 127, 255, 0.08); }
+.world-item.active { background: rgba(58, 127, 255, 0.15); border-left: var(--pixel) solid var(--accent-bright); }
+.world-item .world-name { font-size: 12px; margin-bottom: 2px; }
+.world-item .world-meta { font-size: 10px; color: var(--text-dim); }
+.world-dot { display: inline-block; width: 6px; height: 6px; background: var(--green); margin-right: 4px; }
+.world-dot.offline { background: var(--red); }
+
+/* ── Canvas area (center) ── */
+#canvas-area {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  padding: 16px; gap: 12px;
+}
+
+#canvas-wrap {
+  position: relative;
+  border: var(--pixel) solid var(--border);
+  background: #050508;
+}
+
+canvas {
+  display: block;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+}
+
+#canvas-overlay {
+  position: absolute; inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  background: rgba(5,5,8,0.85);
+  font-size: 12px; color: var(--text-dim);
+  text-align: center; gap: 8px; flex-direction: column;
+}
+#canvas-overlay.hidden { display: none; }
+
+#canvas-controls {
+  display: flex; gap: 8px; align-items: center; flex-wrap: wrap; justify-content: center;
+}
+
+.btn {
+  padding: 5px 12px;
+  background: var(--accent);
+  color: #fff;
+  border: none; cursor: pointer;
+  font-family: inherit; font-size: 12px;
+  letter-spacing: 1px;
+  clip-path: polygon(0 0, calc(100% - 4px) 0, 100% 4px, 100% 100%, 4px 100%, 0 calc(100% - 4px));
+}
+.btn:hover { background: var(--accent-bright); }
+.btn:disabled { background: var(--border); cursor: not-allowed; }
+.btn.danger { background: #661122; }
+.btn.danger:hover { background: var(--red); }
+
+#alias-input {
+  padding: 5px 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit; font-size: 12px;
+  width: 120px;
+}
+
+/* ── Events panel (right) ── */
+#events-panel {
+  width: 240px; flex-shrink: 0;
+  background: var(--surface);
+  border-left: var(--pixel) solid var(--border);
+  display: flex; flex-direction: column;
+}
+
+#events-panel h2 {
+  padding: 10px 12px;
+  font-size: 11px; letter-spacing: 1px; text-transform: uppercase;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--border);
+}
+
+#events-list {
+  flex: 1; overflow-y: auto; padding: 4px 0;
+  display: flex; flex-direction: column-reverse;
+}
+
+.event-item {
+  padding: 4px 10px;
+  font-size: 11px; border-bottom: 1px solid var(--border);
+}
+.event-item .ev-time { color: var(--text-dim); margin-right: 4px; }
+.event-item.join { color: var(--green); }
+.event-item.leave { color: var(--red); }
+.event-item.action { color: var(--text); }
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar { width: 4px; }
+::-webkit-scrollbar-track { background: var(--bg); }
+::-webkit-scrollbar-thumb { background: var(--border); }


### PR DESCRIPTION
Closes #60

Zero-dependency browser frontend for the DAP Agent playground.

## Files
- `web/index.html` — single HTML file, no framework
- `web/style.css` — pixel dark theme with CSS clip-path buttons
- `web/client.js` — vanilla JS + Canvas

## Features
- 32×32 pixel grid, each agent rendered as a colored pixel sprite
- Agent color derived from agentId (deterministic, no config)
- Own agent highlighted with white border
- Click canvas or WASD/arrows to move
- Alias input before joining
- Real-time events log (right panel)
- World list fetched from Gateway `GET /worlds`, refreshes every 15s
- WebSocket to Gateway `/ws?world=<worldId>`

## Depends on
- PR #64 (Gateway Server)

## Usage (local dev)
```bash
# Start a world agent
WORLD_ID=test PEER_PORT=8099 PUBLIC_ADDR=127.0.0.1 node world/server.mjs

# Start gateway
PEER_PORT=9099 HTTP_PORT=8100 node gateway/server.mjs

# Serve frontend
npx serve web -p 3000
# or just open web/index.html directly (if gateway on same host)
```