### PR TITLE
fix: reject probe responses without worldId for world peers

### DIFF
--- a/.changeset/probe-worldid-check.md
+++ b/.changeset/probe-worldid-check.md
@@ -1,0 +1,5 @@
+---
+"@resciencelab/dap": patch
+---
+
+Gateway probe rejects endpoints that return no worldId (e.g. Gateway's own peer listener on same port)

--- a/gateway/server.mjs
+++ b/gateway/server.mjs
@@ -284,8 +284,11 @@ async function probeWorldReachable(peer) {
       const res = await fetch(url, { signal: AbortSignal.timeout(5_000) });
       if (res.ok) {
         const data = await res.json().catch(() => ({}));
-        // If the ping response contains a worldId, verify it matches
-        if (data.worldId && expectedWorldId && data.worldId !== expectedWorldId) return false;
+        // World agents must return worldId in ping response
+        if (expectedWorldId) {
+          if (!data.worldId) return false; // not a world agent (e.g. gateway)
+          if (data.worldId !== expectedWorldId) return false; // port collision
+        }
         return true;
       }
     } catch {}


### PR DESCRIPTION
## Problem

The Gateway's active world probing passed for stale ghost worlds because their announced endpoint (`3.17.5.202:8099`) happened to be the Gateway's own peer listener port. The Gateway's `/peer/ping` returns `{ role: "gateway" }` with no `worldId` field, so the check `if (data.worldId && expectedWorldId && ...)` was skipped entirely -- falling through to `return true`.

## Fix

When probing a world peer's endpoint, if the `/peer/ping` response has no `worldId`, treat it as not a world agent and return `false`. This correctly filters out:
- Gateway's own peer listener responding on the same port
- Any non-world service that happens to respond to `/peer/ping`

## Verified

Deployed to EC2 Gateway -- immediately cleaned up 2 ghost worlds:
```
Discovered 3 world(s), 2 unreachable removed, 1 live, 12 peers total
```