### PR TITLE
fix: correct package name in bootstrap-addrs changeset

### DIFF
--- a/.changeset/bootstrap-addrs.md
+++ b/.changeset/bootstrap-addrs.md
@@ -1,5 +1,5 @@
 ---
-"dap": patch
+"@resciencelab/dap": patch
 ---
 
 Configure public HTTP addresses for all 5 AWS bootstrap nodes


### PR DESCRIPTION
The changeset used bare `"dap"` instead of `"@resciencelab/dap"`, causing `changeset version` to fail with "package not in workspace". Fixes the release.yml failure on run [23184441894](https://github.com/ReScienceLab/DAP/actions/runs/23184441894).