### PR TITLE
fix: remove @resciencelab/agent-world-sdk from changesets

### DIFF
--- a/.changeset/agentwire-p0-http-signing.md
+++ b/.changeset/agentwire-p0-http-signing.md
@@ -1,6 +1,5 @@
 ---
 "@resciencelab/dap": minor
-"@resciencelab/agent-world-sdk": minor
 ---
 
 feat(agentwire-p0): add AgentWire v0.2 HTTP header signing and eliminate gateway crypto duplication

--- a/.changeset/agentwire-p1.md
+++ b/.changeset/agentwire-p1.md
@@ -1,6 +1,5 @@
 ---
 "@resciencelab/dap": minor
-"@resciencelab/agent-world-sdk": minor
 ---
 
 feat(agentwire-p1): AgentWire v0.2 agentId namespace + Agent Card


### PR DESCRIPTION
The SDK package is not configured as an npm workspace, so `changesets version` fails with:

```
Error: Found changeset agentwire-p0-http-signing for package @resciencelab/agent-world-sdk which is not in the workspace
```

This removes `@resciencelab/agent-world-sdk` from the P0 and P1 changeset frontmatter, keeping only `@resciencelab/dap`.

Fixes the release CI failure: https://github.com/ReScienceLab/DAP/actions/runs/23230839876/job/67523808243