### PR TITLE
feat: AgentWorld P2 — response signing, key rotation alignment, protocol rename

### DIFF
--- a/.changeset/agentworld-p2.md
+++ b/.changeset/agentworld-p2.md
@@ -1,0 +1,15 @@
+---
+"@resciencelab/dap": minor
+---
+
+feat(p2): response signing, key rotation format, Agent Card ETag + capabilities
+
+- HTTP response signing: all `/peer/*` JSON responses include `X-AgentWorld-Signature` + `Content-Digest`
+- Key rotation: structured `agentworld-identity-rotation` format with JWS proofs, top-level `oldAgentId`/`newAgentId`
+- TOFU guard: key-loss recovery returns 403 (silent overwrite no longer allowed)
+- Agent Card: `ETag` + `Cache-Control` headers, `conformance.capabilities` array
+- Protocol version derived from `package.json` instead of hardcoded
+- Renamed protocol headers from `X-AgentWire-*` to `X-AgentWorld-*`
+- Renamed card extension key from `extensions.agentwire` to `extensions.agentworld`
+- Raw request body used for Content-Digest verification (prevents false 403 on re-serialization mismatch)
+- Malformed `publicKeyMultibase` returns 400 instead of 500

--- a/bootstrap/server.mjs
+++ b/bootstrap/server.mjs
@@ -35,7 +35,7 @@ const tofuCache = new Map();  // agentId -> publicKey b64
 // Crypto helpers
 // ---------------------------------------------------------------------------
 
-/** Derive agentId from a base64 Ed25519 public key — AgentWire v0.2 aw:sha256: format */
+/** Derive agentId from a base64 Ed25519 public key — AgentWorld v0.2 aw:sha256: format */
 function agentIdFromPublicKey(publicKeyB64) {
   const pubBytes = Buffer.from(publicKeyB64, "base64");
   return `aw:sha256:${crypto.createHash("sha256").update(pubBytes).digest("hex")}`;

--- a/gateway/server.mjs
+++ b/gateway/server.mjs
@@ -292,6 +292,16 @@ async function discoverWorlds() {
 async function startPeerListener() {
   const peerServer = Fastify({ logger: false });
 
+  // Preserve raw request body for Content-Digest verification
+  peerServer.addContentTypeParser("application/json", { parseAs: "string" }, (req, body, done) => {
+    try {
+      req.rawBody = body;
+      done(null, JSON.parse(body));
+    } catch (err) {
+      done(err, undefined);
+    }
+  });
+
   peerServer.get("/peer/ping", async () => ({ ok: true, ts: Date.now(), role: "gateway" }));
   peerServer.get("/peer/peers", async () => ({ peers: getPeersForExchange() }));
 
@@ -299,11 +309,10 @@ async function startPeerListener() {
     const ann = req.body;
     if (!ann?.publicKey || !ann?.from) return reply.code(400).send({ error: "Invalid announce" });
 
-    const awSig = req.headers["x-agentwire-signature"];
+    const awSig = req.headers["x-agentworld-signature"];
     if (awSig) {
-      const rawBody = JSON.stringify(canonicalize(ann));
       const authority = req.headers["host"] ?? "localhost";
-      const result = verifyHttpRequestHeaders(req.headers, req.method, req.url, authority, rawBody, ann.publicKey);
+      const result = verifyHttpRequestHeaders(req.headers, req.method, req.url, authority, req.rawBody, ann.publicKey);
       if (!result.ok) return reply.code(403).send({ error: result.error });
     } else {
       const { signature, ...signable } = ann;
@@ -325,11 +334,10 @@ async function startPeerListener() {
     const msg = req.body;
     if (!msg?.publicKey || !msg?.from) return reply.code(400).send({ error: "Invalid message" });
 
-    const awSig = req.headers["x-agentwire-signature"];
+    const awSig = req.headers["x-agentworld-signature"];
     if (awSig) {
-      const rawBody = JSON.stringify(canonicalize(msg));
       const authority = req.headers["host"] ?? "localhost";
-      const result = verifyHttpRequestHeaders(req.headers, req.method, req.url, authority, rawBody, msg.publicKey);
+      const result = verifyHttpRequestHeaders(req.headers, req.method, req.url, authority, req.rawBody, msg.publicKey);
       if (!result.ok) return reply.code(403).send({ error: result.error });
     } else {
       const { signature, ...signable } = msg;

--- a/packages/agent-world-sdk/package-lock.json
+++ b/packages/agent-world-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@resciencelab/agent-world-sdk",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@resciencelab/agent-world-sdk",
-      "version": "0.1.0",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "fastify": "^5.0.0",

--- a/packages/agent-world-sdk/package.json
+++ b/packages/agent-world-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resciencelab/agent-world-sdk",
-  "version": "0.1.0",
+  "version": "0.3.2",
   "description": "Reusable DAP World Agent infrastructure — crypto, identity, peer DB, bootstrap, peer protocol",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent-world-sdk/src/card.ts
+++ b/packages/agent-world-sdk/src/card.ts
@@ -1,8 +1,8 @@
 /**
- * AgentWire v0.2 Agent Card builder.
+ * AgentWorld v0.2 Agent Card builder.
  *
  * Builds and JWS-signs a standard A2A-compatible Agent Card with an
- * `extensions.agentwire` block. The card is served at /.well-known/agent.json.
+ * `extensions.agentworld` block. The card is served at /.well-known/agent.json.
  *
  * Signing uses jose FlattenedSign (EdDSA/Ed25519). The `payload` field is
  * omitted from the stored signature entry — the card body itself is the
@@ -12,6 +12,7 @@ import { FlattenedSign } from "jose"
 import { createPrivateKey } from "node:crypto"
 import { canonicalize } from "./crypto.js"
 import { deriveDidKey, toPublicKeyMultibase } from "./identity.js"
+import { PROTOCOL_VERSION } from "./version.js"
 import type { Identity } from "./types.js"
 
 // PKCS8 DER header for an Ed25519 32-byte seed (RFC 8410)
@@ -31,7 +32,7 @@ export interface AgentCardOpts {
   cardUrl: string
   /** A2A JSON-RPC endpoint URL (optional) */
   rpcUrl?: string
-  /** AgentWire profiles to declare. Defaults to ["core/v0.2"] */
+  /** AgentWorld profiles to declare. Defaults to ["core/v0.2"] */
   profiles?: string[]
   /** Conformance node class. Defaults to "CoreNode" */
   nodeClass?: string
@@ -40,7 +41,7 @@ export interface AgentCardOpts {
 }
 
 /**
- * Build and JWS-sign an AgentWire v0.2 Agent Card.
+ * Build and JWS-sign an AgentWorld v0.2 Agent Card.
  *
  * Returns the canonical JSON string that MUST be served verbatim as
  * `application/json`. The JWS signature covers
@@ -63,8 +64,8 @@ export async function buildSignedAgentCard(
     ...(opts.description ? { description: opts.description } : {}),
     ...(opts.rpcUrl ? { a2a: { rpcUrl: opts.rpcUrl } } : {}),
     extensions: {
-      agentwire: {
-        version: "0.2",
+      agentworld: {
+        version: PROTOCOL_VERSION,
         agentId: identity.agentId,
         identityMode: "direct",
         identity: {
@@ -75,12 +76,12 @@ export async function buildSignedAgentCard(
         },
         requestSigning: {
           headers: [
-            "X-AgentWire-Version",
-            "X-AgentWire-From",
-            "X-AgentWire-KeyId",
-            "X-AgentWire-Timestamp",
+            "X-AgentWorld-Version",
+            "X-AgentWorld-From",
+            "X-AgentWorld-KeyId",
+            "X-AgentWorld-Timestamp",
             "Content-Digest",
-            "X-AgentWire-Signature",
+            "X-AgentWorld-Signature",
           ],
         },
         profiles,

--- a/packages/agent-world-sdk/src/crypto.ts
+++ b/packages/agent-world-sdk/src/crypto.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto"
 import nacl from "tweetnacl"
+import { PROTOCOL_VERSION } from "./version.js"
 
 export function agentIdFromPublicKey(publicKeyB64: string): string {
   const fullHex = crypto.createHash("sha256")
@@ -39,7 +40,7 @@ export function signPayload(payload: unknown, secretKey: Uint8Array): string {
   return Buffer.from(sig).toString("base64")
 }
 
-// ── AgentWire v0.2 HTTP header signing ───────────────────────────────────────
+// ── AgentWorld v0.2 HTTP header signing ───────────────────────────────────────
 
 const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000
 
@@ -49,12 +50,12 @@ export function computeContentDigest(body: string): string {
 }
 
 export interface AwRequestHeaders {
-  "X-AgentWire-Version": string
-  "X-AgentWire-From": string
-  "X-AgentWire-KeyId": string
-  "X-AgentWire-Timestamp": string
+  "X-AgentWorld-Version": string
+  "X-AgentWorld-From": string
+  "X-AgentWorld-KeyId": string
+  "X-AgentWorld-Timestamp": string
   "Content-Digest": string
-  "X-AgentWire-Signature": string
+  "X-AgentWorld-Signature": string
 }
 
 function buildRequestSigningInput(opts: {
@@ -67,7 +68,7 @@ function buildRequestSigningInput(opts: {
   contentDigest: string
 }): Record<string, string> {
   return {
-    v: "0.2",
+    v: PROTOCOL_VERSION,
     from: opts.from,
     kid: opts.kid,
     ts: opts.ts,
@@ -79,7 +80,7 @@ function buildRequestSigningInput(opts: {
 }
 
 /**
- * Produce AgentWire v0.2 HTTP request signing headers.
+ * Produce AgentWorld v0.2 HTTP request signing headers.
  * Include alongside Content-Type in outbound fetch calls.
  */
 export function signHttpRequest(
@@ -100,17 +101,17 @@ export function signHttpRequest(
     identity.secretKey
   )
   return {
-    "X-AgentWire-Version": "0.2",
-    "X-AgentWire-From": identity.agentId,
-    "X-AgentWire-KeyId": kid,
-    "X-AgentWire-Timestamp": ts,
+    "X-AgentWorld-Version": PROTOCOL_VERSION,
+    "X-AgentWorld-From": identity.agentId,
+    "X-AgentWorld-KeyId": kid,
+    "X-AgentWorld-Timestamp": ts,
     "Content-Digest": contentDigest,
-    "X-AgentWire-Signature": Buffer.from(sig).toString("base64"),
+    "X-AgentWorld-Signature": Buffer.from(sig).toString("base64"),
   }
 }
 
 /**
- * Verify AgentWire v0.2 HTTP request headers.
+ * Verify AgentWorld v0.2 HTTP request headers.
  * Returns { ok: true } if valid, { ok: false, error } otherwise.
  */
 export function verifyHttpRequestHeaders(
@@ -125,19 +126,19 @@ export function verifyHttpRequestHeaders(
   const h: Record<string, string | string[] | undefined> = {}
   for (const [k, v] of Object.entries(headers)) h[k.toLowerCase()] = v
 
-  const sig = h["x-agentwire-signature"] as string | undefined
-  const from = h["x-agentwire-from"] as string | undefined
-  const kid = h["x-agentwire-keyid"] as string | undefined
-  const ts = h["x-agentwire-timestamp"] as string | undefined
+  const sig = h["x-agentworld-signature"] as string | undefined
+  const from = h["x-agentworld-from"] as string | undefined
+  const kid = h["x-agentworld-keyid"] as string | undefined
+  const ts = h["x-agentworld-timestamp"] as string | undefined
   const cd = h["content-digest"] as string | undefined
 
   if (!sig || !from || !kid || !ts || !cd) {
-    return { ok: false, error: "Missing required AgentWire headers" }
+    return { ok: false, error: "Missing required AgentWorld headers" }
   }
 
   const tsDiff = Math.abs(Date.now() - new Date(ts).getTime())
   if (isNaN(tsDiff) || tsDiff > MAX_CLOCK_SKEW_MS) {
-    return { ok: false, error: "X-AgentWire-Timestamp outside acceptable skew window" }
+    return { ok: false, error: "X-AgentWorld-Timestamp outside acceptable skew window" }
   }
 
   const expectedDigest = computeContentDigest(body)
@@ -149,18 +150,18 @@ export function verifyHttpRequestHeaders(
     from, kid, ts, method, authority, path, contentDigest: cd,
   })
   const ok = verifySignature(publicKeyB64, signingInput, sig)
-  return ok ? { ok: true } : { ok: false, error: "Invalid X-AgentWire-Signature" }
+  return ok ? { ok: true } : { ok: false, error: "Invalid X-AgentWorld-Signature" }
 }
 
-// ── AgentWire v0.2 HTTP response signing ─────────────────────────────────────
+// ── AgentWorld v0.2 HTTP response signing ─────────────────────────────────────
 
 export interface AwResponseHeaders {
-  "X-AgentWire-Version": string
-  "X-AgentWire-From": string
-  "X-AgentWire-KeyId": string
-  "X-AgentWire-Timestamp": string
+  "X-AgentWorld-Version": string
+  "X-AgentWorld-From": string
+  "X-AgentWorld-KeyId": string
+  "X-AgentWorld-Timestamp": string
   "Content-Digest": string
-  "X-AgentWire-Signature": string
+  "X-AgentWorld-Signature": string
 }
 
 function buildResponseSigningInput(opts: {
@@ -171,7 +172,7 @@ function buildResponseSigningInput(opts: {
   contentDigest: string
 }): Record<string, unknown> {
   return {
-    v: "0.2",
+    v: PROTOCOL_VERSION,
     from: opts.from,
     kid: opts.kid,
     ts: opts.ts,
@@ -181,7 +182,7 @@ function buildResponseSigningInput(opts: {
 }
 
 /**
- * Produce AgentWire v0.2 HTTP response signing headers.
+ * Produce AgentWorld v0.2 HTTP response signing headers.
  * Add to Fastify reply before sending the body.
  */
 export function signHttpResponse(
@@ -200,17 +201,17 @@ export function signHttpResponse(
     identity.secretKey
   )
   return {
-    "X-AgentWire-Version": "0.2",
-    "X-AgentWire-From": identity.agentId,
-    "X-AgentWire-KeyId": kid,
-    "X-AgentWire-Timestamp": ts,
+    "X-AgentWorld-Version": PROTOCOL_VERSION,
+    "X-AgentWorld-From": identity.agentId,
+    "X-AgentWorld-KeyId": kid,
+    "X-AgentWorld-Timestamp": ts,
     "Content-Digest": contentDigest,
-    "X-AgentWire-Signature": Buffer.from(sig).toString("base64"),
+    "X-AgentWorld-Signature": Buffer.from(sig).toString("base64"),
   }
 }
 
 /**
- * Verify AgentWire v0.2 HTTP response headers from an inbound response.
+ * Verify AgentWorld v0.2 HTTP response headers from an inbound response.
  * Returns { ok: true } if valid, { ok: false, error } otherwise.
  */
 export function verifyHttpResponseHeaders(
@@ -223,19 +224,19 @@ export function verifyHttpResponseHeaders(
   const h: Record<string, string | null> = {}
   for (const [k, v] of Object.entries(headers)) h[k.toLowerCase()] = v
 
-  const sig = h["x-agentwire-signature"]
-  const from = h["x-agentwire-from"]
-  const kid = h["x-agentwire-keyid"]
-  const ts = h["x-agentwire-timestamp"]
+  const sig = h["x-agentworld-signature"]
+  const from = h["x-agentworld-from"]
+  const kid = h["x-agentworld-keyid"]
+  const ts = h["x-agentworld-timestamp"]
   const cd = h["content-digest"]
 
   if (!sig || !from || !kid || !ts || !cd) {
-    return { ok: false, error: "Missing required AgentWire response headers" }
+    return { ok: false, error: "Missing required AgentWorld response headers" }
   }
 
   const tsDiff = Math.abs(Date.now() - new Date(ts).getTime())
   if (isNaN(tsDiff) || tsDiff > MAX_CLOCK_SKEW_MS) {
-    return { ok: false, error: "X-AgentWire-Timestamp outside acceptable skew window" }
+    return { ok: false, error: "X-AgentWorld-Timestamp outside acceptable skew window" }
   }
 
   const expectedDigest = computeContentDigest(body)
@@ -245,5 +246,5 @@ export function verifyHttpResponseHeaders(
 
   const signingInput = buildResponseSigningInput({ from, kid, ts, status, contentDigest: cd })
   const ok = verifySignature(publicKeyB64, signingInput, sig)
-  return ok ? { ok: true } : { ok: false, error: "Invalid X-AgentWire-Signature" }
+  return ok ? { ok: true } : { ok: false, error: "Invalid X-AgentWorld-Signature" }
 }

--- a/packages/agent-world-sdk/src/index.ts
+++ b/packages/agent-world-sdk/src/index.ts
@@ -1,3 +1,4 @@
+export { PROTOCOL_VERSION } from "./version.js"
 export { agentIdFromPublicKey, canonicalize, verifySignature, signPayload, computeContentDigest, signHttpRequest, verifyHttpRequestHeaders, signHttpResponse, verifyHttpResponseHeaders } from "./crypto.js"
 export type { AwRequestHeaders, AwResponseHeaders } from "./crypto.js"
 export { loadOrCreateIdentity, deriveDidKey, toPublicKeyMultibase } from "./identity.js"

--- a/packages/agent-world-sdk/src/peer-protocol.ts
+++ b/packages/agent-world-sdk/src/peer-protocol.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify"
 import { createHash } from "node:crypto"
 import { agentIdFromPublicKey, canonicalize, verifySignature, verifyHttpRequestHeaders, signHttpResponse } from "./crypto.js"
+import { PROTOCOL_VERSION } from "./version.js"
 import { buildSignedAgentCard } from "./card.js"
 import type { AgentCardOpts } from "./card.js"
 import type { Identity, KeyRotationRequest } from "./types.js"
@@ -37,7 +38,24 @@ export function registerPeerRoutes(
 ): void {
   const { identity, peerDb, pingExtra, onMessage, card } = opts
 
-  // Sign all /peer/* JSON responses (P2a — AgentWire v0.2 response signing)
+  // Custom JSON parser that preserves the raw body string for digest verification.
+  // The raw bytes are stored on req.rawBody so verifyHttpRequestHeaders can check
+  // Content-Digest against exactly what the sender transmitted.
+  fastify.decorateRequest("rawBody", "")
+  fastify.addContentTypeParser(
+    "application/json",
+    { parseAs: "string" },
+    (req, body, done) => {
+      try {
+        ;(req as unknown as { rawBody: string }).rawBody = body as string
+        done(null, JSON.parse(body as string))
+      } catch (err) {
+        done(err as Error, undefined)
+      }
+    }
+  )
+
+  // Sign all /peer/* JSON responses (P2a — AgentWorld v0.2 response signing)
   fastify.addHook("onSend", async (_req, reply, payload) => {
     if (typeof payload !== "string") return payload
     const url = (_req.url ?? "").split("?")[0]
@@ -84,9 +102,9 @@ export function registerPeerRoutes(
       return reply.code(400).send({ error: "Invalid announce" })
     }
 
-    const awSig = req.headers["x-agentwire-signature"]
+    const awSig = req.headers["x-agentworld-signature"]
     if (awSig) {
-      const rawBody = JSON.stringify(canonicalize(ann))
+      const rawBody = (req as unknown as { rawBody: string }).rawBody
       const authority = (req.headers["host"] as string) ?? "localhost"
       const result = verifyHttpRequestHeaders(
         req.headers as Record<string, string>,
@@ -117,9 +135,9 @@ export function registerPeerRoutes(
       return reply.code(400).send({ error: "Invalid message" })
     }
 
-    const awSig = req.headers["x-agentwire-signature"]
+    const awSig = req.headers["x-agentworld-signature"]
     if (awSig) {
-      const rawBody = JSON.stringify(canonicalize(msg))
+      const rawBody = (req as unknown as { rawBody: string }).rawBody
       const authority = (req.headers["host"] as string) ?? "localhost"
       const result = verifyHttpRequestHeaders(
         req.headers as Record<string, string>,
@@ -168,20 +186,22 @@ export function registerPeerRoutes(
     }
   })
 
-  // POST /peer/key-rotation — AgentWire v0.2 §6.10/§10.4
+  // POST /peer/key-rotation — AgentWorld v0.2 §6.10/§10.4
   fastify.post("/peer/key-rotation", async (req, reply) => {
     const rot = req.body as unknown as KeyRotationRequest
 
-    if (rot?.type !== "key-rotation" || rot?.version !== "0.2") {
-      return reply.code(400).send({ error: "Expected type=key-rotation and version=0.2" })
+    if (rot?.type !== "agentworld-identity-rotation" || rot?.version !== PROTOCOL_VERSION) {
+      return reply.code(400).send({ error: `Expected type=agentworld-identity-rotation and version=${PROTOCOL_VERSION}` })
     }
 
-    if (!rot.oldIdentity?.agentId || !rot.oldIdentity?.publicKeyMultibase ||
-        !rot.newIdentity?.publicKeyMultibase || !rot.proofs?.signedByOld || !rot.proofs?.signedByNew) {
+    if (!rot.oldAgentId || !rot.newAgentId ||
+        !rot.oldIdentity?.publicKeyMultibase ||
+        !rot.newIdentity?.publicKeyMultibase ||
+        !rot.proofs?.signedByOld?.signature || !rot.proofs?.signedByNew?.signature) {
       return reply.code(400).send({ error: "Missing required key rotation fields" })
     }
 
-    const agentId = rot.oldIdentity.agentId
+    const agentId = rot.oldAgentId
     let oldPublicKeyB64: string, newPublicKeyB64: string
     try {
       oldPublicKeyB64 = multibaseToBase64(rot.oldIdentity.publicKeyMultibase)
@@ -206,10 +226,10 @@ export function registerPeerRoutes(
       newPublicKey: newPublicKeyB64,
       timestamp,
     }
-    if (!verifySignature(oldPublicKeyB64, signable, rot.proofs.signedByOld)) {
+    if (!verifySignature(oldPublicKeyB64, signable, rot.proofs.signedByOld.signature)) {
       return reply.code(403).send({ error: "Invalid signatureByOldKey" })
     }
-    if (!verifySignature(newPublicKeyB64, signable, rot.proofs.signedByNew)) {
+    if (!verifySignature(newPublicKeyB64, signable, rot.proofs.signedByNew.signature)) {
       return reply.code(403).send({ error: "Invalid signatureByNewKey" })
     }
 

--- a/packages/agent-world-sdk/src/types.ts
+++ b/packages/agent-world-sdk/src/types.ts
@@ -95,7 +95,7 @@ export interface WorldServer {
   stop(): Promise<void>
 }
 
-// ── Key rotation (AgentWire v0.2 §6.10/§10.4) ────────────────────────────────
+// ── Key rotation (AgentWorld v0.2 §6.10/§10.4) ────────────────────────────────
 
 export interface KeyRotationIdentity {
   agentId: string
@@ -103,10 +103,17 @@ export interface KeyRotationIdentity {
   publicKeyMultibase: string
 }
 
+export interface KeyRotationProof {
+  protected: string
+  signature: string
+}
+
 export interface KeyRotationRequest {
-  type: "key-rotation"
-  version: "0.2"
+  type: "agentworld-identity-rotation"
+  version: string
   logicalCardUrl?: string
+  oldAgentId: string
+  newAgentId: string
   oldIdentity: KeyRotationIdentity
   newIdentity: KeyRotationIdentity
   timestamp: number
@@ -116,7 +123,7 @@ export interface KeyRotationRequest {
   overlapUntil?: string
   reason?: string
   proofs: {
-    signedByOld: string
-    signedByNew: string
+    signedByOld: KeyRotationProof
+    signedByNew: KeyRotationProof
   }
 }

--- a/packages/agent-world-sdk/src/version.ts
+++ b/packages/agent-world-sdk/src/version.ts
@@ -1,0 +1,4 @@
+import { createRequire } from "node:module"
+const require = createRequire(import.meta.url)
+const pkg = require("../package.json")
+export const PROTOCOL_VERSION: string = pkg.version

--- a/packages/agent-world-sdk/tsconfig.json
+++ b/packages/agent-world-sdk/tsconfig.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "resolveJsonModule": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/src/peer-server.ts
+++ b/src/peer-server.ts
@@ -13,6 +13,8 @@ import { createHash } from "node:crypto"
 import * as nacl from "tweetnacl"
 import { P2PMessage, Endpoint } from "./types"
 import { verifySignature, agentIdFromPublicKey, canonicalize } from "./identity"
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { version: PROTOCOL_VERSION } = require("../package.json")
 import { tofuVerifyAndCache, tofuReplaceKey, getPeersForExchange, upsertDiscoveredPeer, removePeer, getPeer } from "./peer-db"
 
 const MAX_MESSAGE_AGE_MS = 5 * 60 * 1000 // 5 minutes
@@ -72,7 +74,7 @@ function signResponse(status: number, bodyStr: string): Record<string, string> |
   const kid = "#identity"
   const contentDigest = computeContentDigest(bodyStr)
   const signingInput = canonicalize({
-    v: "0.2",
+    v: PROTOCOL_VERSION,
     from: _signingKey.agentId,
     kid,
     ts,
@@ -84,12 +86,12 @@ function signResponse(status: number, bodyStr: string): Record<string, string> |
     _signingKey.secretKey
   )
   return {
-    "X-AgentWire-Version": "0.2",
-    "X-AgentWire-From": _signingKey.agentId,
-    "X-AgentWire-KeyId": kid,
-    "X-AgentWire-Timestamp": ts,
+    "X-AgentWorld-Version": PROTOCOL_VERSION,
+    "X-AgentWorld-From": _signingKey.agentId,
+    "X-AgentWorld-KeyId": kid,
+    "X-AgentWorld-Timestamp": ts,
     "Content-Digest": contentDigest,
-    "X-AgentWire-Signature": Buffer.from(sig).toString("base64"),
+    "X-AgentWorld-Signature": Buffer.from(sig).toString("base64"),
   }
 }
 
@@ -102,7 +104,7 @@ export async function startPeerServer(port: number = 8099, opts?: PeerServerOpti
 
   server = Fastify({ logger: false })
 
-  // Sign all /peer/* JSON responses (P2a — AgentWire v0.2 response signing)
+  // Sign all /peer/* JSON responses (P2a — AgentWorld v0.2 response signing)
   server.addHook("onSend", async (_req, reply, payload) => {
     if (!_signingKey || typeof payload !== "string") return payload
     const url = ((_req as any).url ?? "").split("?")[0] as string
@@ -225,16 +227,18 @@ export async function startPeerServer(port: number = 8099, opts?: PeerServerOpti
   server.post("/peer/key-rotation", async (req, reply) => {
     const rot = req.body as any
 
-    if (!rot.oldIdentity?.agentId || !rot.oldIdentity?.publicKeyMultibase ||
-        !rot.newIdentity?.publicKeyMultibase || !rot.proofs?.signedByOld || !rot.proofs?.signedByNew) {
+    if (!rot.oldAgentId || !rot.newAgentId ||
+        !rot.oldIdentity?.publicKeyMultibase ||
+        !rot.newIdentity?.publicKeyMultibase ||
+        !rot.proofs?.signedByOld?.signature || !rot.proofs?.signedByNew?.signature) {
       return reply.code(400).send({ error: "Missing required key rotation fields" })
     }
 
-    if (rot.type !== "key-rotation" || rot.version !== "0.2") {
-      return reply.code(400).send({ error: "Expected type=key-rotation and version=0.2" })
+    if (rot.type !== "agentworld-identity-rotation" || rot.version !== PROTOCOL_VERSION) {
+      return reply.code(400).send({ error: `Expected type=agentworld-identity-rotation and version=${PROTOCOL_VERSION}` })
     }
 
-    const agentId: string = rot.oldIdentity.agentId
+    const agentId: string = rot.oldAgentId
     let oldPublicKeyB64: string, newPublicKeyB64: string
     try {
       oldPublicKeyB64 = multibaseToBase64(rot.oldIdentity.publicKeyMultibase)
@@ -259,11 +263,11 @@ export async function startPeerServer(port: number = 8099, opts?: PeerServerOpti
       timestamp,
     }
 
-    if (!verifySignature(oldPublicKeyB64, signable, rot.proofs.signedByOld)) {
+    if (!verifySignature(oldPublicKeyB64, signable, rot.proofs.signedByOld.signature)) {
       return reply.code(403).send({ error: "Invalid signatureByOldKey" })
     }
 
-    if (!verifySignature(newPublicKeyB64, signable, rot.proofs.signedByNew)) {
+    if (!verifySignature(newPublicKeyB64, signable, rot.proofs.signedByNew.signature)) {
       return reply.code(403).send({ error: "Invalid signatureByNewKey" })
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export interface PluginConfig {
   tofu_ttl_days?: number
 }
 
-// ── Key rotation (AgentWire v0.2 §6.10/§10.4) ────────────────────────────────
+// ── Key rotation (AgentWorld v0.2 §6.10/§10.4) ────────────────────────────────
 
 export interface KeyRotationIdentity {
   agentId: string
@@ -87,10 +87,17 @@ export interface KeyRotationIdentity {
   publicKeyMultibase: string
 }
 
+export interface KeyRotationProof {
+  protected: string
+  signature: string
+}
+
 export interface KeyRotationRequestV2 {
-  type: "key-rotation"
-  version: "0.2"
+  type: "agentworld-identity-rotation"
+  version: string
   logicalCardUrl?: string
+  oldAgentId: string
+  newAgentId: string
   oldIdentity: KeyRotationIdentity
   newIdentity: KeyRotationIdentity
   timestamp: number
@@ -98,7 +105,7 @@ export interface KeyRotationRequestV2 {
   overlapUntil?: string
   reason?: string
   proofs: {
-    signedByOld: string
-    signedByNew: string
+    signedByOld: KeyRotationProof
+    signedByNew: KeyRotationProof
   }
 }

--- a/test/key-rotation.test.mjs
+++ b/test/key-rotation.test.mjs
@@ -6,6 +6,10 @@ import * as path from "node:path"
 
 const nacl = (await import("tweetnacl")).default
 
+import { createRequire } from "node:module"
+const require = createRequire(import.meta.url)
+const { version: PROTOCOL_VERSION } = require("../package.json")
+
 const { startPeerServer, stopPeerServer } = await import("../dist/peer-server.js")
 const { initDb } = await import("../dist/peer-db.js")
 const { signMessage, agentIdFromPublicKey } = await import("../dist/identity.js")
@@ -46,6 +50,12 @@ function pubToMultibase(pubB64) {
   return `z${str}`
 }
 
+function makeProof(kid, privB64, signable) {
+  const header = JSON.stringify({ alg: "EdDSA", kid })
+  const protectedB64 = Buffer.from(header).toString("base64url")
+  return { protected: protectedB64, signature: sign(privB64, signable) }
+}
+
 function makeRotationBody(oldKey, newKey, overrideProofOld) {
   const signable = {
     agentId: oldKey.agentId,
@@ -54,14 +64,16 @@ function makeRotationBody(oldKey, newKey, overrideProofOld) {
     timestamp: Date.now(),
   }
   return {
-    type: "key-rotation",
-    version: "0.2",
+    type: "agentworld-identity-rotation",
+    version: PROTOCOL_VERSION,
+    oldAgentId: oldKey.agentId,
+    newAgentId: newKey.agentId,
     oldIdentity: { agentId: oldKey.agentId, kid: "#identity", publicKeyMultibase: pubToMultibase(oldKey.publicKey) },
     newIdentity: { agentId: newKey.agentId, kid: "#identity", publicKeyMultibase: pubToMultibase(newKey.publicKey) },
     timestamp: signable.timestamp,
     proofs: {
-      signedByOld: sign(overrideProofOld ?? oldKey.privateKey, signable),
-      signedByNew: sign(newKey.privateKey, signable),
+      signedByOld: makeProof("#identity", overrideProofOld ?? oldKey.privateKey, signable),
+      signedByNew: makeProof("#identity", newKey.privateKey, signable),
     },
   }
 }
@@ -107,7 +119,7 @@ describe("key rotation endpoint", () => {
     assert.equal(resp.status, 403)
   })
 
-  test("rejects mismatched agentId (oldIdentity.agentId does not match oldPublicKey)", async () => {
+  test("rejects mismatched agentId (oldAgentId does not match oldPublicKey)", async () => {
     const oldKey = makeKeypair()
     const newKey = makeKeypair()
     const otherKey = makeKeypair()
@@ -118,14 +130,16 @@ describe("key rotation endpoint", () => {
       timestamp: Date.now(),
     }
     const body = {
-      type: "key-rotation",
-      version: "0.2",
+      type: "agentworld-identity-rotation",
+      version: PROTOCOL_VERSION,
+      oldAgentId: otherKey.agentId,
+      newAgentId: newKey.agentId,
       oldIdentity: { agentId: otherKey.agentId, kid: "#identity", publicKeyMultibase: pubToMultibase(oldKey.publicKey) },
       newIdentity: { agentId: newKey.agentId, kid: "#identity", publicKeyMultibase: pubToMultibase(newKey.publicKey) },
       timestamp: signable.timestamp,
       proofs: {
-        signedByOld: sign(oldKey.privateKey, signable),
-        signedByNew: sign(newKey.privateKey, signable),
+        signedByOld: makeProof("#identity", oldKey.privateKey, signable),
+        signedByNew: makeProof("#identity", newKey.privateKey, signable),
       },
     }
     const resp = await fetch(`http://[::1]:${port}/peer/key-rotation`, {
@@ -140,7 +154,7 @@ describe("key rotation endpoint", () => {
     const resp = await fetch(`http://[::1]:${port}/peer/key-rotation`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ type: "key-rotation", version: "0.2" }),
+      body: JSON.stringify({ type: "agentworld-identity-rotation", version: PROTOCOL_VERSION }),
     })
     assert.equal(resp.status, 400)
   })
@@ -149,7 +163,7 @@ describe("key rotation endpoint", () => {
     const resp = await fetch(`http://[::1]:${port}/peer/key-rotation`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ agentId: "x", oldPublicKey: "x", newPublicKey: "x" }),
+      body: JSON.stringify({ type: "key-rotation", version: PROTOCOL_VERSION, oldAgentId: "x" }),
     })
     assert.equal(resp.status, 400)
   })
@@ -182,8 +196,10 @@ describe("key rotation endpoint", () => {
       timestamp: Date.now(),
     }
     const body = {
-      type: "key-rotation",
-      version: "0.2",
+      type: "agentworld-identity-rotation",
+      version: PROTOCOL_VERSION,
+      oldAgentId: tofuKey.agentId,
+      newAgentId: newKey.agentId,
       oldIdentity: {
         agentId: tofuKey.agentId,
         kid: "#identity",
@@ -192,8 +208,8 @@ describe("key rotation endpoint", () => {
       newIdentity: { agentId: newKey.agentId, kid: "#identity", publicKeyMultibase: pubToMultibase(newKey.publicKey) },
       timestamp: signable.timestamp,
       proofs: {
-        signedByOld: sign(attackerKey.privateKey, signable),
-        signedByNew: sign(newKey.privateKey, signable),
+        signedByOld: makeProof("#identity", attackerKey.privateKey, signable),
+        signedByNew: makeProof("#identity", newKey.privateKey, signable),
       },
     }
     const resp = await fetch(`http://[::1]:${port}/peer/key-rotation`, {

--- a/test/response-signing.test.mjs
+++ b/test/response-signing.test.mjs
@@ -1,8 +1,8 @@
 /**
- * P2a — AgentWire v0.2 response signing
+ * P2a — AgentWorld v0.2 response signing
  *
- * Verifies that /peer/* endpoints include X-AgentWire-Signature,
- * X-AgentWire-From, Content-Digest and other required headers, and that
+ * Verifies that /peer/* endpoints include X-AgentWorld-Signature,
+ * X-AgentWorld-From, Content-Digest and other required headers, and that
  * the signature is cryptographically valid over the response body.
  */
 import { test, describe, before, after } from "node:test"
@@ -11,6 +11,10 @@ import * as os from "node:os"
 import * as fs from "node:fs"
 import * as path from "node:path"
 import crypto from "node:crypto"
+
+import { createRequire } from "node:module"
+const require = createRequire(import.meta.url)
+const { version: PROTOCOL_VERSION } = require("../package.json")
 
 const nacl = (await import("tweetnacl")).default
 
@@ -44,10 +48,10 @@ function canonicalize(value) {
 }
 
 function verifyResponseSig(headers, status, body, publicKeyB64) {
-  const sig = headers.get("x-agentwire-signature")
-  const from = headers.get("x-agentwire-from")
-  const kid = headers.get("x-agentwire-keyid")
-  const ts = headers.get("x-agentwire-timestamp")
+  const sig = headers.get("x-agentworld-signature")
+  const from = headers.get("x-agentworld-from")
+  const kid = headers.get("x-agentworld-keyid")
+  const ts = headers.get("x-agentworld-timestamp")
   const cd = headers.get("content-digest")
 
   if (!sig || !from || !kid || !ts || !cd) return { ok: false, missing: true }
@@ -55,7 +59,7 @@ function verifyResponseSig(headers, status, body, publicKeyB64) {
   const expectedDigest = computeContentDigest(body)
   if (cd !== expectedDigest) return { ok: false, digestMismatch: true }
 
-  const signingInput = canonicalize({ v: "0.2", from, kid, ts, status, contentDigest: cd })
+  const signingInput = canonicalize({ v: PROTOCOL_VERSION, from, kid, ts, status, contentDigest: cd })
   const pubBytes = Buffer.from(publicKeyB64, "base64")
   const sigBytes = Buffer.from(sig, "base64")
   const msg = Buffer.from(JSON.stringify(signingInput))
@@ -79,22 +83,22 @@ describe("P2a — response signing on /peer/* endpoints", () => {
     fs.rmSync(tmpDir, { recursive: true })
   })
 
-  test("/peer/ping response has valid AgentWire signature headers", async () => {
+  test("/peer/ping response has valid AgentWorld signature headers", async () => {
     const resp = await fetch(`http://[::1]:${PORT}/peer/ping`)
     const body = await resp.text()
     assert.equal(resp.status, 200)
 
-    assert.ok(resp.headers.get("x-agentwire-signature"), "missing X-AgentWire-Signature")
-    assert.ok(resp.headers.get("x-agentwire-from"), "missing X-AgentWire-From")
-    assert.ok(resp.headers.get("x-agentwire-keyid"), "missing X-AgentWire-KeyId")
-    assert.ok(resp.headers.get("x-agentwire-timestamp"), "missing X-AgentWire-Timestamp")
+    assert.ok(resp.headers.get("x-agentworld-signature"), "missing X-AgentWorld-Signature")
+    assert.ok(resp.headers.get("x-agentworld-from"), "missing X-AgentWorld-From")
+    assert.ok(resp.headers.get("x-agentworld-keyid"), "missing X-AgentWorld-KeyId")
+    assert.ok(resp.headers.get("x-agentworld-timestamp"), "missing X-AgentWorld-Timestamp")
     assert.ok(resp.headers.get("content-digest"), "missing Content-Digest")
 
     const result = verifyResponseSig(resp.headers, 200, body, selfKey.publicKey)
     assert.ok(result.ok, `Response signature invalid: ${JSON.stringify(result)}`)
   })
 
-  test("/peer/peers response has valid AgentWire signature headers", async () => {
+  test("/peer/peers response has valid AgentWorld signature headers", async () => {
     const resp = await fetch(`http://[::1]:${PORT}/peer/peers`)
     const body = await resp.text()
     assert.equal(resp.status, 200)


### PR DESCRIPTION
## Summary

Lands P2 changes that were missing from the PR #76 squash merge.

### Changes

**Response signing (P2a)**
- All `/peer/*` JSON responses include `X-AgentWorld-Signature` + `Content-Digest`
- `signHttpResponse()` + `verifyHttpResponseHeaders()` in SDK crypto module
- Fastify `onSend` hook in both peer-server.ts and peer-protocol.ts

**Key rotation format alignment (P2b)**
- Type: `agentworld-identity-rotation` (was `key-rotation`)
- Proofs: JWS `{protected, signature}` objects (was flat base64)
- Top-level `oldAgentId`/`newAgentId` fields added
- TOFU guard: key-loss recovery returns 403

**Agent Card enhancements (P2c/P2d)**
- `ETag` + `Cache-Control` headers on `/.well-known/agent.json`
- `conformance.capabilities` array with default core capabilities

**Protocol rename**
- HTTP headers: `X-AgentWire-*` → `X-AgentWorld-*`
- Card extension: `extensions.agentwire` → `extensions.agentworld`

**Fixes**
- `PROTOCOL_VERSION` from `package.json` instead of hardcoded `"0.2"`
- Raw request body for Content-Digest verification (prevents false 403)
- Malformed `publicKeyMultibase` returns 400 instead of 500
- Response header key normalization for round-trip verification
- SDK version unified to 0.3.2

### Tests
97/97 pass