### PR TITLE
fix: install and build agent-world-sdk in CI workflows

### DIFF
--- a/.changeset/sdk-ci-install.md
+++ b/.changeset/sdk-ci-install.md
@@ -1,0 +1,5 @@
+---
+"@resciencelab/dap": patch
+---
+
+fix: install and build agent-world-sdk in CI workflows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
+      - run: npm --prefix packages/agent-world-sdk install
       - run: npm run build
+      - run: npm --prefix packages/agent-world-sdk run build
       - run: node --test test/*.test.mjs
 
       # Creates a "Version Packages" PR when changesets are pending,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm ci
+      - run: npm --prefix packages/agent-world-sdk install
       - run: npm run build
+      - run: npm --prefix packages/agent-world-sdk run build
       - run: node --test test/*.test.mjs
 
 


### PR DESCRIPTION
CI `npm ci` at root doesn't install SDK dependencies, causing `jose` module-not-found during `npm run release`.

Adds `npm --prefix packages/agent-world-sdk install` and build steps to both `test.yml` and `release.yml`.