### PR TITLE
fix: add NPM_TOKEN env to release workflow

### DIFF
--- a/.changeset/npm-token-fix.md
+++ b/.changeset/npm-token-fix.md
@@ -1,0 +1,5 @@
+---
+"@resciencelab/dap": patch
+---
+
+fix: add NPM_TOKEN env to release workflow for changesets publish detection

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to ClawHub


### PR DESCRIPTION
`changesets/action` checks for `NPM_TOKEN` env var to detect npm auth availability. The workflow only had `NODE_AUTH_TOKEN`, causing:

```
No NPM_TOKEN or OIDC available - assuming npm is already authenticated
```

This adds `NPM_TOKEN` alongside `NODE_AUTH_TOKEN` so changesets can properly authenticate for npm publish.