### PR TITLE
fix: use cd for SDK npm publish instead of --prefix

### DIFF
--- a/.changeset/sdk-publish-fix.md
+++ b/.changeset/sdk-publish-fix.md
@@ -1,0 +1,5 @@
+---
+"@resciencelab/dap": patch
+---
+
+fix: use cd instead of --prefix for SDK npm publish to avoid publishing root package

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "version": "changeset version && node scripts/sync-version.mjs",
-    "release": "npm run build && npm --prefix packages/agent-world-sdk run build && changeset publish && npm --prefix packages/agent-world-sdk publish --access public",
+    "release": "npm run build && npm --prefix packages/agent-world-sdk run build && changeset publish && cd packages/agent-world-sdk && npm publish --access public",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {


### PR DESCRIPTION
## Problem

`npm --prefix packages/agent-world-sdk publish` was publishing the root `@resciencelab/dap` package instead of `@resciencelab/agent-world-sdk`. This caused a 403 (version already published) and the SDK never got published.

## Fix

Replace `npm --prefix packages/agent-world-sdk publish` with `cd packages/agent-world-sdk && npm publish` to ensure npm reads the correct `package.json`.