### PR TITLE
fix: remove SDK from changesets — not a workspace package

### DIFF
--- a/.changeset/domain-separated-signing.md
+++ b/.changeset/domain-separated-signing.md
@@ -1,5 +1,5 @@
 ---
-"@resciencelab/agent-world-sdk": minor
+"@resciencelab/dap": minor
 ---
 
 Implement domain-separated signatures to prevent cross-context replay attacks

--- a/.changeset/v02-request-signing.md
+++ b/.changeset/v02-request-signing.md
@@ -1,6 +1,5 @@
 ---
 "@resciencelab/dap": minor
-"@resciencelab/agent-world-sdk": minor
 ---
 
 feat: domain-separated signing, header-only auth, world ledger

--- a/.changeset/world-types.md
+++ b/.changeset/world-types.md
@@ -1,6 +1,5 @@
 ---
 "@resciencelab/dap": minor
-"@resciencelab/agent-world-sdk": minor
 ---
 
 feat: add world type system — programmatic and hosted world modes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1894,7 +1894,7 @@
     },
     "packages/agent-world-sdk": {
       "name": "@resciencelab/agent-world-sdk",
-      "version": "0.3.2",
+      "version": "0.4.3",
       "extraneous": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
The Release workflow fails because changesets references `@resciencelab/agent-world-sdk` which is not registered as an npm workspace.

**Root cause**: The SDK lives under `packages/agent-world-sdk/` but the root `package.json` has no `workspaces` field. Changesets can only version packages it knows about.

**Fix**: Remove `@resciencelab/agent-world-sdk` from all changeset files. The SDK version is already synced via `scripts/sync-version.mjs` (copies root version to SDK `package.json`) and published in the release script (`cd packages/agent-world-sdk && npm publish`).

148/148 tests pass.