### PR TITLE
feat: Gateway persistence, graceful shutdown, and health observability

### DIFF
--- a/.hal/prd.json
+++ b/.hal/prd.json
@@ -106,7 +106,7 @@
         "Tests pass"
       ],
       "priority": 6,
-      "passes": false,
+      "passes": true,
       "notes": ""
     }
   ]

--- a/.hal/progress.txt
+++ b/.hal/progress.txt
@@ -6,6 +6,7 @@
 - In `gateway/server.mjs`, registry persistence side effects should stay explicit: announce-driven `upsertAgent()` calls opt into debounced saves, while prune/shutdown paths use `flushRegistry()` for immediate durability.
 - In `gateway/server.mjs`, `/peer/message` is relay-only: it should verify and forward `world.state` payloads, but registry membership must come only from `/peer/announce`.
 - In `gateway/server.mjs`, lifecycle cleanup should retain server and timer handles in module scope so signal handlers can flush the registry once, clear intervals, and close listeners idempotently.
+- In `gateway/server.mjs`, `/health` must keep `ok: true` for compatibility while deriving `status` from registry contents: `ready` when `worlds > 0`, `warming` when `agents > 0` but no worlds, and `empty` when the registry is empty.
 
 (Add reusable patterns discovered during implementation here)
 
@@ -51,4 +52,12 @@
   - Gateway shutdown logic should be idempotent because both `SIGTERM` and `SIGINT` can arrive; caching a shared shutdown promise avoids double-closing Fastify instances.
   - Retaining the prune interval handle in module state is necessary so shutdown can stop background work before the process exits naturally.
   - There is no `gateway/AGENTS.md` in this repo, so reusable gateway-specific notes for this area should go into `.hal/progress.txt` unless a local agent guide is added later.
+---
+## 2026-03-21 17:04:10 UTC - US-006
+- Enhanced `/health` in `gateway/server.mjs` to report `registryAge` from tracked registry mutations/load state and to expose compatibility-safe readiness statuses (`ready`, `warming`, `empty`) while preserving `ok: true`.
+- Files changed: `gateway/server.mjs`, `.hal/prd.json`, `.hal/progress.txt`
+- **Learnings for future iterations:**
+  - Health freshness should be tracked separately from persistence writes; `_registryModifiedAt` reflects registry load or mutation time, while `registryAge` becomes `null` whenever the in-memory registry is empty.
+  - Gateway observability changes should stay additive on `/health`; keep the endpoint unauthenticated and backward compatible by preserving `ok: true` and existing top-level fields.
+  - There is still no `gateway/AGENTS.md`, so reusable gateway health conventions belong in `.hal/progress.txt` unless a local guide is introduced later.
 ---

--- a/gateway/server.mjs
+++ b/gateway/server.mjs
@@ -73,6 +73,7 @@ const registry = new Map() // agentId -> PeerRecord
 let _saveTimer = null
 let _pruneTimer = null
 let _shutdownPromise = null
+let _registryModifiedAt = null
 
 function writeRegistry() {
   fs.mkdirSync(DATA_DIR, { recursive: true })
@@ -89,6 +90,7 @@ function loadRegistry() {
   if (!fs.existsSync(REGISTRY_PATH)) {
     console.warn(`[gateway] Registry file missing at ${REGISTRY_PATH}; starting with empty registry`)
     registry.clear()
+    _registryModifiedAt = null
     return
   }
 
@@ -117,10 +119,14 @@ function loadRegistry() {
       loaded++
     }
 
+    _registryModifiedAt = loaded > 0
+      ? (typeof raw.savedAt === "number" ? raw.savedAt : Date.now())
+      : null
     console.log(`[gateway] Loaded ${loaded} agents from registry (discarded ${discarded} stale)`)
   } catch (error) {
     console.warn(`[gateway] Failed to load registry from ${REGISTRY_PATH}; starting with empty registry`, error)
     registry.clear()
+    _registryModifiedAt = null
   }
 }
 
@@ -173,6 +179,9 @@ function upsertAgent(agentId, publicKey, opts = {}) {
     const oldest = [...registry.values()].sort((a, b) => a.lastSeen - b.lastSeen)[0]
     registry.delete(oldest.agentId)
     trimmed = true
+  }
+  if (changed || trimmed) {
+    _registryModifiedAt = now
   }
   if (persist && (changed || trimmed)) {
     saveRegistry()
@@ -362,10 +371,25 @@ const app = Fastify({ logger: false });
 await app.register(cors, { origin: true });
 await app.register(websocketPlugin);
 
-app.get("/health", async () => ({
-  ok: true, ts: Date.now(), agentId: selfAgentId,
-  agents: registry.size, worlds: findByCapability("world:").length,
-}));
+app.get("/health", async () => {
+  const ts = Date.now()
+  const worlds = findByCapability("world:").length
+  const agents = registry.size
+  const registryAge = agents > 0 && _registryModifiedAt !== null
+    ? Math.max(0, ts - _registryModifiedAt)
+    : null
+  const status = worlds > 0 ? "ready" : agents > 0 ? "warming" : "empty"
+
+  return {
+    ok: true,
+    ts,
+    agentId: selfAgentId,
+    agents,
+    worlds,
+    registryAge,
+    status,
+  }
+});
 
 // Agent Card — served as canonical JSON so bytes on wire match the JWS signature
 let _cachedCardJson = null


### PR DESCRIPTION
## Summary

- **US-001**: Rename internal `peers` → `registry`, `upsertPeer` → `upsertAgent`, `MAX_PEERS` → `MAX_AGENTS` for self-documenting code
- **US-002**: Add `loadRegistry()` / `saveRegistry()` / `flushRegistry()` with atomic writes (`registry.json.tmp` → rename) and 1s debounce
- **US-003**: Wire persistence into announce and prune flows so registry survives restarts
- **US-004**: Stop `/peer/message` from polluting registry with empty records; tune `STALE_TTL_MS` to 15min, prune interval to 3min
- **US-005**: Graceful shutdown on `SIGTERM`/`SIGINT` — flush registry, close both Fastify servers, clear intervals
- **US-006**: Enhance `/health` with `registryAge`, `status` (ready/warming/empty), keeping `ok: true` for backward compat

## Test plan

- [ ] `node --check gateway/server.mjs` passes
- [ ] `npm run build` passes
- [ ] `node --test test/*.test.mjs` passes
- [ ] Start gateway, announce a world, restart gateway — world persists in `/data/registry.json`
- [ ] `/health` returns `status`, `registryAge`, and `ok: true`
- [ ] `SIGTERM` flushes registry before exit

🤖 Generated with [hal](https://github.com/ReScienceLab/hal) + [Claude Code](https://claude.com/claude-code)