### PR TITLE
fix: deploy ECR auth via credential helper, fix SSM polling

### DIFF
--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -52,41 +52,58 @@ jobs:
         run: |
           IMAGE="$REGISTRY/$ECR_REPOSITORY:${{ github.sha }}"
 
+          # Build SSM parameters via jq to avoid quoting issues.
+          # The instance role has ecr-pull permissions, so we use the ECR
+          # credential helper for authentication instead of the aws CLI.
+          PARAMS=$(jq -cn \
+            --arg pull "docker pull $IMAGE" \
+            --arg run "docker run -d --name awn-gateway --restart unless-stopped -p 8099:8099 -p 8100:8100 -v /opt/awn-gateway/data:/data -e PEER_PORT=8099 -e HTTP_PORT=8100 -e DATA_DIR=/data $IMAGE" \
+            '{commands: [
+              "command -v amazon-ecr-credential-helper >/dev/null 2>&1 || apt-get install -y amazon-ecr-credential-helper",
+              "mkdir -p /root/.docker && printf '"'"'{\"credsStore\":\"ecr-login\"}'"'"' > /root/.docker/config.json",
+              $pull,
+              "docker stop awn-gateway 2>/dev/null || true",
+              "docker rm awn-gateway 2>/dev/null || true",
+              $run
+            ]}')
+
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
-            --parameters commands="[
-              \"aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin $REGISTRY\",
-              \"docker pull $IMAGE\",
-              \"docker stop awn-gateway 2>/dev/null || true\",
-              \"docker rm awn-gateway 2>/dev/null || true\",
-              \"docker run -d --name awn-gateway --restart unless-stopped -p 8099:8099 -p 8100:8100 -v /opt/awn-gateway/data:/data -e PEER_PORT=8099 -e HTTP_PORT=8100 -e DATA_DIR=/data $IMAGE\"
-            ]" \
+            --parameters "$PARAMS" \
+            --region us-east-2 \
             --query "Command.CommandId" \
             --output text)
 
           echo "SSM Command ID: $COMMAND_ID"
 
+          sleep 5
+
           for i in $(seq 1 30); do
-            STATUS=$(aws ssm get-command-invocation \
+            if STATUS=$(aws ssm get-command-invocation \
               --command-id "$COMMAND_ID" \
               --instance-id "$INSTANCE_ID" \
+              --region us-east-2 \
               --query "Status" \
-              --output text 2>/dev/null || echo "Pending")
+              --output text 2>&1); then
 
-            echo "Attempt $i: Status=$STATUS"
+              echo "Attempt $i: Status=$STATUS"
 
-            if [ "$STATUS" = "Success" ]; then
-              echo "Deploy command succeeded"
-              exit 0
-            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
-              echo "Deploy command failed with status: $STATUS"
-              aws ssm get-command-invocation \
-                --command-id "$COMMAND_ID" \
-                --instance-id "$INSTANCE_ID" \
-                --query "StandardErrorContent" \
-                --output text
-              exit 1
+              if [ "$STATUS" = "Success" ]; then
+                echo "Deploy command succeeded"
+                exit 0
+              elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
+                echo "Deploy command failed with status: $STATUS"
+                aws ssm get-command-invocation \
+                  --command-id "$COMMAND_ID" \
+                  --instance-id "$INSTANCE_ID" \
+                  --region us-east-2 \
+                  --query "StandardErrorContent" \
+                  --output text
+                exit 1
+              fi
+            else
+              echo "Attempt $i: GetCommandInvocation error (will retry): $STATUS"
             fi
 
             sleep 10
@@ -101,6 +118,7 @@ jobs:
             --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" \
             --parameters commands='["sleep 5","curl -sf http://localhost:8100/health"]' \
+            --region us-east-2 \
             --query "Command.CommandId" \
             --output text)
 
@@ -109,6 +127,7 @@ jobs:
           STATUS=$(aws ssm get-command-invocation \
             --command-id "$COMMAND_ID" \
             --instance-id "$INSTANCE_ID" \
+            --region us-east-2 \
             --query "Status" \
             --output text)
 
@@ -119,6 +138,7 @@ jobs:
             aws ssm get-command-invocation \
               --command-id "$COMMAND_ID" \
               --instance-id "$INSTANCE_ID" \
+              --region us-east-2 \
               --query "StandardErrorContent" \
               --output text
             exit 1


### PR DESCRIPTION
## Problem

The CI run [#23384809680](https://github.com/ReScienceLab/agent-world-network/actions/runs/23384809680/job/68030000346) failed at the **Deploy via SSM** step.

Two bugs were found by inspecting the actual SSM command invocation:

### 1. `aws: not found` on the EC2 instance

The deploy command ran `aws ecr get-login-password` but the AWS CLI is not installed on the instance. The instance IAM role (`openclaw-p2p-ssm-role`) already has `ecr:GetAuthorizationToken` via the `ecr-pull` inline policy, so no AWS CLI is needed.

**Fix:** Install `amazon-ecr-credential-helper` (available via `apt`) and write a Docker config that delegates credential lookups to it. Docker then authenticates via the instance profile automatically.

### 2. Silent error masking caused all 30 polls to report `Pending`

The `get-command-invocation` call used `2>/dev/null || echo Pending`, which swallowed any API error (e.g. missing `ssm:GetCommandInvocation` IAM permission, or invocation not yet registered). The command had actually `Failed` in 0.15 s, but the CI never saw it.

**Fix:** Remove `2>/dev/null`, capture stderr into the status variable, print it on failure and retry instead of treating every error as `Pending`.

## Changes

- Replace `aws ecr get-login-password | docker login` with `amazon-ecr-credential-helper` setup (no AWS CLI required on instance)
- Build SSM parameters via `jq` to avoid nested-quoting issues
- Add explicit `--region us-east-2` to all SSM calls
- Fix `GetCommandInvocation` error masking: show error and retry instead of silently mapping to `Pending`
- Add `sleep 5` before the first poll to let the invocation record be registered

Fixes #105