### PR TITLE
fix: kill stale port holders before docker run

### DIFF
--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -64,6 +64,8 @@ jobs:
               $pull,
               "docker stop awn-gateway 2>/dev/null || true",
               "docker rm awn-gateway 2>/dev/null || true",
+              "fuser -k 8099/tcp 2>/dev/null || true",
+              "fuser -k 8100/tcp 2>/dev/null || true",
               $run
             ]}')
 


### PR DESCRIPTION
The old `dap-bootstrap` Node.js process holds port 8099 even after `docker rm awn-gateway`, causing `docker run` to fail with *address already in use*. Adding `fuser -k 8099/tcp` and `8100/tcp` before the run clears any leftover listeners.

skip-changelog