### PR TITLE
fix(sdk): validate newAgentId ↔ newPublicKey binding in key rotation [2/4]

### DIFF
--- a/.changeset/fix-key-rotation-validation.md
+++ b/.changeset/fix-key-rotation-validation.md
@@ -1,0 +1,10 @@
+---
+"@resciencelab/agent-world-sdk": patch
+---
+
+fix(sdk): validate newAgentId matches newPublicKey in key rotation handler
+
+The `/peer/key-rotation` endpoint verified `oldAgentId ↔ oldPublicKey` but never
+checked that `newAgentId` matches `newPublicKey`. An attacker could submit a rotation
+request with arbitrary `newAgentId` metadata. Added `agentIdFromPublicKey()` validation
+for the new identity, returning 400 on mismatch.

--- a/packages/agent-world-sdk/src/peer-protocol.ts
+++ b/packages/agent-world-sdk/src/peer-protocol.ts
@@ -281,6 +281,12 @@ export function registerPeerRoutes(
         .code(400)
         .send({ error: "agentId does not match oldPublicKey" });
     }
+    const expectedNewAgentId = agentIdFromPublicKey(newPublicKeyB64);
+    if (expectedNewAgentId !== rot.newAgentId) {
+      return reply
+        .code(400)
+        .send({ error: "newAgentId does not match newPublicKey" });
+    }
 
     const MAX_AGE_MS = 5 * 60 * 1000;
     if (timestamp && Math.abs(Date.now() - timestamp) > MAX_AGE_MS) {

--- a/src/peer-server.ts
+++ b/src/peer-server.ts
@@ -235,6 +235,10 @@ export async function startPeerServer(port: number = 8099, opts?: PeerServerOpti
     if (agentIdFromPublicKey(oldPublicKeyB64) !== agentId) {
       return reply.code(400).send({ error: "agentId does not match oldPublicKey" })
     }
+    const expectedNewAgentId = agentIdFromPublicKey(newPublicKeyB64)
+    if (expectedNewAgentId !== rot.newAgentId) {
+      return reply.code(400).send({ error: "newAgentId does not match newPublicKey" })
+    }
 
     if (timestamp && Math.abs(Date.now() - timestamp) > MAX_MESSAGE_AGE_MS) {
       return reply.code(400).send({ error: "Key rotation timestamp too old or too far in the future" })

--- a/test/key-rotation-sdk.test.mjs
+++ b/test/key-rotation-sdk.test.mjs
@@ -1,0 +1,145 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import Fastify from "fastify"
+
+const nacl = (await import("tweetnacl")).default
+
+const {
+  registerPeerRoutes,
+  PeerDb,
+  PROTOCOL_VERSION,
+  agentIdFromPublicKey,
+  signWithDomainSeparator,
+  DOMAIN_SEPARATORS,
+  toPublicKeyMultibase,
+} = await import("../packages/agent-world-sdk/dist/index.js")
+
+function makeIdentity() {
+  const keypair = nacl.sign.keyPair()
+  const pubB64 = Buffer.from(keypair.publicKey).toString("base64")
+  return {
+    agentId: agentIdFromPublicKey(pubB64),
+    pubB64,
+    secretKey: keypair.secretKey,
+    keypair,
+  }
+}
+
+function makeProof(secretKey, signable) {
+  const header = JSON.stringify({ alg: "EdDSA", kid: "#identity" })
+  return {
+    protected: Buffer.from(header).toString("base64url"),
+    signature: signWithDomainSeparator(
+      DOMAIN_SEPARATORS.KEY_ROTATION,
+      signable,
+      secretKey
+    ),
+  }
+}
+
+function makeApp(t) {
+  const fastify = Fastify({ logger: false })
+  t.after(async () => {
+    await fastify.close()
+  })
+
+  const peerDb = new PeerDb()
+  registerPeerRoutes(fastify, {
+    identity: makeIdentity(),
+    peerDb,
+  })
+
+  return { fastify, peerDb }
+}
+
+test("sdk /peer/key-rotation rejects mismatched newAgentId binding with stable 400 error", async (t) => {
+  const { fastify } = makeApp(t)
+
+  const oldKey = makeIdentity()
+  const newKey = makeIdentity()
+  const otherNewKey = makeIdentity()
+  const timestamp = Date.now()
+  const signable = {
+    agentId: oldKey.agentId,
+    oldPublicKey: oldKey.pubB64,
+    newPublicKey: newKey.pubB64,
+    timestamp,
+  }
+
+  const response = await fastify.inject({
+    method: "POST",
+    url: "/peer/key-rotation",
+    headers: { "content-type": "application/json" },
+    payload: {
+      type: "agentworld-identity-rotation",
+      version: PROTOCOL_VERSION,
+      oldAgentId: oldKey.agentId,
+      newAgentId: otherNewKey.agentId,
+      oldIdentity: {
+        agentId: oldKey.agentId,
+        kid: "#identity",
+        publicKeyMultibase: toPublicKeyMultibase(oldKey.pubB64),
+      },
+      newIdentity: {
+        agentId: otherNewKey.agentId,
+        kid: "#identity",
+        publicKeyMultibase: toPublicKeyMultibase(newKey.pubB64),
+      },
+      timestamp,
+      proofs: {
+        signedByOld: makeProof(oldKey.secretKey, signable),
+        signedByNew: makeProof(newKey.secretKey, signable),
+      },
+    },
+  })
+
+  assert.equal(response.statusCode, 400)
+  assert.deepEqual(response.json(), {
+    error: "newAgentId does not match newPublicKey",
+  })
+})
+
+test("sdk /peer/key-rotation accepts correctly bound rotations and persists the new key", async (t) => {
+  const { fastify, peerDb } = makeApp(t)
+
+  const oldKey = makeIdentity()
+  const newKey = makeIdentity()
+  const timestamp = Date.now()
+  const signable = {
+    agentId: oldKey.agentId,
+    oldPublicKey: oldKey.pubB64,
+    newPublicKey: newKey.pubB64,
+    timestamp,
+  }
+
+  const response = await fastify.inject({
+    method: "POST",
+    url: "/peer/key-rotation",
+    headers: { "content-type": "application/json" },
+    payload: {
+      type: "agentworld-identity-rotation",
+      version: PROTOCOL_VERSION,
+      oldAgentId: oldKey.agentId,
+      newAgentId: newKey.agentId,
+      oldIdentity: {
+        agentId: oldKey.agentId,
+        kid: "#identity",
+        publicKeyMultibase: toPublicKeyMultibase(oldKey.pubB64),
+      },
+      newIdentity: {
+        agentId: newKey.agentId,
+        kid: "#identity",
+        publicKeyMultibase: toPublicKeyMultibase(newKey.pubB64),
+      },
+      timestamp,
+      proofs: {
+        signedByOld: makeProof(oldKey.secretKey, signable),
+        signedByNew: makeProof(newKey.secretKey, signable),
+      },
+    },
+  })
+
+  assert.equal(response.statusCode, 200)
+  assert.deepEqual(response.json(), { ok: true })
+  assert.equal(peerDb.get(oldKey.agentId)?.publicKey, newKey.pubB64)
+})

--- a/test/key-rotation.test.mjs
+++ b/test/key-rotation.test.mjs
@@ -12,7 +12,7 @@ const pkgVersion = require("../package.json").version
 const PROTOCOL_VERSION = pkgVersion.split(".").slice(0, 2).join(".")
 
 const { startPeerServer, stopPeerServer, addWorldMembers } = await import("../dist/peer-server.js")
-const { initDb } = await import("../dist/peer-db.js")
+const { initDb, getPeer } = await import("../dist/peer-db.js")
 const { agentIdFromPublicKey, signWithDomainSeparator, DOMAIN_SEPARATORS, signHttpRequest, canonicalize } = await import("../dist/identity.js")
 
 function makeKeypair() {
@@ -184,6 +184,120 @@ describe("key rotation endpoint", () => {
       body: JSON.stringify({ type: "agentworld-identity-rotation", version: PROTOCOL_VERSION }),
     })
     assert.equal(resp.status, 400)
+  })
+
+  test("rejects mismatched rotated identity binding with stable 400 error", async () => {
+    const oldKey = makeKeypair()
+    const newKey = makeKeypair()
+    const otherNewKey = makeKeypair()
+    addWorldMembers("test-world", [oldKey.agentId])
+
+    const signable = {
+      agentId: oldKey.agentId,
+      oldPublicKey: oldKey.publicKey,
+      newPublicKey: newKey.publicKey,
+      timestamp: Date.now(),
+    }
+    const body = {
+      type: "agentworld-identity-rotation",
+      version: PROTOCOL_VERSION,
+      oldAgentId: oldKey.agentId,
+      newAgentId: otherNewKey.agentId,
+      oldIdentity: {
+        agentId: oldKey.agentId,
+        kid: "#identity",
+        publicKeyMultibase: pubToMultibase(oldKey.publicKey),
+      },
+      newIdentity: {
+        agentId: otherNewKey.agentId,
+        kid: "#identity",
+        publicKeyMultibase: pubToMultibase(newKey.publicKey),
+      },
+      timestamp: signable.timestamp,
+      proofs: {
+        signedByOld: makeProof("#identity", oldKey.secretKey, signable),
+        signedByNew: makeProof("#identity", newKey.secretKey, signable),
+      },
+    }
+
+    const resp = await fetch(`http://[::1]:${port}/peer/key-rotation`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+
+    assert.equal(resp.status, 400)
+    assert.deepEqual(await resp.json(), {
+      error: "newAgentId does not match newPublicKey",
+    })
+  })
+
+  test("rejects mismatched rotated identity binding before mutating stored key state", async () => {
+    const oldKey = makeKeypair()
+    const attemptedNewKey = makeKeypair()
+    const otherNewKey = makeKeypair()
+    addWorldMembers("test-world", [oldKey.agentId])
+
+    const validSeedResp = await sendSignedMessage(port, oldKey, {
+      from: oldKey.agentId,
+      publicKey: oldKey.publicKey,
+      event: "ping",
+      content: "seed tofu binding",
+      timestamp: Date.now(),
+      signature: signWithDomainSeparator(
+        DOMAIN_SEPARATORS.MESSAGE,
+        {
+          from: oldKey.agentId,
+          publicKey: oldKey.publicKey,
+          event: "ping",
+          content: "seed tofu binding",
+          timestamp: Date.now(),
+        },
+        oldKey.secretKey
+      ),
+    })
+    assert.equal(validSeedResp.status, 200)
+    assert.equal(getPeer(oldKey.agentId)?.publicKey, oldKey.publicKey)
+
+    const signable = {
+      agentId: oldKey.agentId,
+      oldPublicKey: oldKey.publicKey,
+      newPublicKey: attemptedNewKey.publicKey,
+      timestamp: Date.now(),
+    }
+    const body = {
+      type: "agentworld-identity-rotation",
+      version: PROTOCOL_VERSION,
+      oldAgentId: oldKey.agentId,
+      newAgentId: otherNewKey.agentId,
+      oldIdentity: {
+        agentId: oldKey.agentId,
+        kid: "#identity",
+        publicKeyMultibase: pubToMultibase(oldKey.publicKey),
+      },
+      newIdentity: {
+        agentId: otherNewKey.agentId,
+        kid: "#identity",
+        publicKeyMultibase: pubToMultibase(attemptedNewKey.publicKey),
+      },
+      timestamp: signable.timestamp,
+      proofs: {
+        signedByOld: makeProof("#identity", oldKey.secretKey, signable),
+        signedByNew: makeProof("#identity", attemptedNewKey.secretKey, signable),
+      },
+    }
+
+    const resp = await fetch(`http://[::1]:${port}/peer/key-rotation`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+
+    assert.equal(resp.status, 400)
+    assert.deepEqual(await resp.json(), {
+      error: "newAgentId does not match newPublicKey",
+    })
+    assert.equal(getPeer(oldKey.agentId)?.publicKey, oldKey.publicKey)
   })
 
   test("rejects wrong type/version", async () => {


### PR DESCRIPTION
## BUG-3 [MEDIUM] — Key rotation missing newAgentId validation

### Problem
`/peer/key-rotation` verified `oldAgentId ↔ oldPublicKey` but never checked that
`newAgentId` matches `newPublicKey`. An attacker could submit a rotation with
arbitrary `newAgentId` metadata.

### Fix
Added `agentIdFromPublicKey(newPublicKeyB64) !== rot.newAgentId` check in
`peer-protocol.ts`, returning 400 on mismatch.

### Tests
- New `test/key-rotation-sdk.test.mjs` — mismatched newAgentId rejection
- Extended `test/key-rotation.test.mjs` — additional binding validation

### Changeset
`fix-key-rotation-validation.md` — `@resciencelab/agent-world-sdk` patch

### Stack
- ✅ PR #110 — Broadcast leak fix (merged)
- **→ PR 2/4** (this) — Key rotation validation
- PR 3/4 — Base58 codec fix
- PR 4/4 — Protocol consistency