### PR TITLE
fix(sdk): correct base58 encode/decode for leading-zero inputs [3/4]

### DIFF
--- a/.changeset/fix-base58-codec.md
+++ b/.changeset/fix-base58-codec.md
@@ -1,0 +1,10 @@
+---
+"@resciencelab/agent-world-sdk": patch
+---
+
+fix(sdk): correct base58 encode/decode for leading-zero byte inputs
+
+`base58Encode([0])` produced `"11"` instead of `"1"` and `base58Decode("1")` produced
+`[0, 0]` instead of `[0]`. Fixed by skipping trailing zero digits in the encoder and
+rewriting the leading-zero byte handling in the decoder. Not triggered by current
+Ed25519 key usage but now correct for general reuse.

--- a/packages/agent-world-sdk/src/identity.ts
+++ b/packages/agent-world-sdk/src/identity.ts
@@ -9,7 +9,9 @@ import type { Identity } from "./types.js"
 const MULTICODEC_ED25519_PREFIX = Buffer.from([0xed, 0x01])
 const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
-function base58Encode(buf: Buffer): string {
+export function base58Encode(buf: Buffer): string {
+  if (buf.length === 0) return ""
+
   const digits = [0]
   for (const byte of buf) {
     let carry = byte
@@ -23,8 +25,12 @@ function base58Encode(buf: Buffer): string {
       carry = (carry / 58) | 0
     }
   }
-  let str = ""
-  for (let i = 0; i < buf.length && buf[i] === 0; i++) str += "1"
+  let leadingZeroCount = 0
+  while (leadingZeroCount < buf.length && buf[leadingZeroCount] === 0) leadingZeroCount++
+
+  let str = "1".repeat(leadingZeroCount)
+  if (leadingZeroCount === buf.length) return str
+
   for (let i = digits.length - 1; i >= 0; i--) str += BASE58_ALPHABET[digits[i]]
   return str
 }

--- a/packages/agent-world-sdk/src/index.ts
+++ b/packages/agent-world-sdk/src/index.ts
@@ -16,6 +16,7 @@ export {
 export type { AwRequestHeaders, AwResponseHeaders } from "./crypto.js";
 export {
   loadOrCreateIdentity,
+  base58Encode,
   deriveDidKey,
   toPublicKeyMultibase,
 } from "./identity.js";
@@ -23,7 +24,7 @@ export { buildSignedAgentCard, verifyAgentCard } from "./card.js";
 export type { AgentCardOpts } from "./card.js";
 export { PeerDb } from "./peer-db.js";
 export { announceToGateway, startGatewayAnnounce } from "./gateway-announce.js";
-export { registerPeerRoutes } from "./peer-protocol.js";
+export { registerPeerRoutes, multibaseToBase64, base58Decode } from "./peer-protocol.js";
 export { createWorldServer } from "./world-server.js";
 export { WorldLedger } from "./world-ledger.js";
 export type {

--- a/packages/agent-world-sdk/src/peer-protocol.ts
+++ b/packages/agent-world-sdk/src/peer-protocol.ts
@@ -281,6 +281,12 @@ export function registerPeerRoutes(
         .code(400)
         .send({ error: "agentId does not match oldPublicKey" });
     }
+    const expectedNewAgentId = agentIdFromPublicKey(newPublicKeyB64);
+    if (expectedNewAgentId !== rot.newAgentId) {
+      return reply
+        .code(400)
+        .send({ error: "newAgentId does not match newPublicKey" });
+    }
 
     const MAX_AGE_MS = 5 * 60 * 1000;
     if (timestamp && Math.abs(Date.now() - timestamp) > MAX_AGE_MS) {
@@ -330,7 +336,7 @@ export function registerPeerRoutes(
 }
 
 /** Convert a multibase (z<base58btc>) Ed25519 public key to base64. */
-function multibaseToBase64(multibase: string): string {
+export function multibaseToBase64(multibase: string): string {
   if (!multibase.startsWith("z"))
     throw new Error("Unsupported multibase prefix");
   const bytes = base58Decode(multibase.slice(1));
@@ -340,7 +346,9 @@ function multibaseToBase64(multibase: string): string {
 
 const BASE58_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-function base58Decode(str: string): Uint8Array {
+export function base58Decode(str: string): Uint8Array {
+  if (str.length === 0) return new Uint8Array()
+
   const bytes = [0];
   for (const char of str) {
     let carry = BASE58_ALPHABET.indexOf(char);
@@ -355,9 +363,16 @@ function base58Decode(str: string): Uint8Array {
       carry >>= 8;
     }
   }
+
+  let leadingZeroCount = 0
   for (const char of str) {
-    if (char === "1") bytes.push(0);
-    else break;
+    if (char !== "1") break
+    leadingZeroCount++
   }
+
+  if (leadingZeroCount === str.length) return new Uint8Array(leadingZeroCount)
+
+  for (let i = 0; i < leadingZeroCount; i++) bytes.push(0)
+
   return new Uint8Array(bytes.reverse());
 }

--- a/test/base58.test.mjs
+++ b/test/base58.test.mjs
@@ -1,0 +1,61 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { base58Encode, deriveDidKey, toPublicKeyMultibase } from "../packages/agent-world-sdk/dist/identity.js"
+import { base58Decode } from "../packages/agent-world-sdk/dist/peer-protocol.js"
+
+const encodeCases = [
+  { bytes: [0], encoded: "1" },
+  { bytes: [0, 0], encoded: "11" },
+  { bytes: [0, 1], encoded: "12" },
+  { bytes: [1], encoded: "2" },
+  { bytes: [1, 0], encoded: "5R" },
+]
+
+const decodeCases = [
+  { encoded: "1", bytes: [0] },
+  { encoded: "11", bytes: [0, 0] },
+  { encoded: "12", bytes: [0, 1] },
+  { encoded: "2", bytes: [1] },
+  { encoded: "5R", bytes: [1, 0] },
+]
+
+const deterministicPublicKeyB64 = "iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w="
+const deterministicDidKey = "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX"
+const deterministicPublicKeyMultibase = "z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX"
+
+describe("base58Encode", () => {
+  for (const { bytes, encoded } of encodeCases) {
+    it(`encodes [${bytes.join(",")}] as ${encoded}`, () => {
+      assert.equal(base58Encode(Buffer.from(bytes)), encoded)
+    })
+  }
+})
+
+describe("base58Decode", () => {
+  for (const { encoded, bytes } of decodeCases) {
+    it(`decodes ${encoded} as [${bytes.join(",")}]`, () => {
+      assert.deepEqual(Array.from(base58Decode(encoded)), bytes)
+    })
+  }
+})
+
+describe("base58 round trips", () => {
+  for (const { bytes, encoded } of encodeCases) {
+    it(`round-trips [${bytes.join(",")}] byte-for-byte`, () => {
+      assert.equal(encoded, base58Encode(Buffer.from(bytes)))
+      assert.deepEqual(Array.from(base58Decode(encoded)), bytes)
+    })
+  }
+})
+
+describe("deriveDidKey", () => {
+  it("returns the fixed DID for the deterministic fixture", () => {
+    assert.equal(deriveDidKey(deterministicPublicKeyB64), deterministicDidKey)
+  })
+})
+
+describe("toPublicKeyMultibase", () => {
+  it("returns the fixed multibase value for the deterministic fixture", () => {
+    assert.equal(toPublicKeyMultibase(deterministicPublicKeyB64), deterministicPublicKeyMultibase)
+  })
+})


### PR DESCRIPTION
## BUG-2 [MEDIUM] — base58 codec incorrect for leading-zero bytes

### Problem
`base58Encode([0])` → `"11"` (should be `"1"`). Decoder mirror issue.

### Fix
- **identity.ts** — Skip trailing zero digits; early return for all-zero input
- **peer-protocol.ts** — Rewrite leading-zero handling in decoder
- Both exported for testability

### Tests
- New `test/base58.test.mjs` — edge cases, round-trip, `deriveDidKey` regression

### Changeset
`fix-base58-codec.md` — `@resciencelab/agent-world-sdk` patch

### Stack
- ✅ PR #110 — Broadcast leak fix (merged)
- PR #114 — Key rotation validation
- **→ PR 3/4** (this) — Base58 codec fix
- PR 4/4 — Protocol consistency