### PR TITLE
fix(sdk): protocol consistency — domain separator, ledger, Fastify reply [4/4]

### DIFF
--- a/.changeset/fix-protocol-consistency.md
+++ b/.changeset/fix-protocol-consistency.md
@@ -1,0 +1,13 @@
+---
+"@resciencelab/agent-world-sdk": patch
+---
+
+fix(sdk): protocol consistency — domain separator, ledger constant, Fastify reply
+
+- **Domain separator mismatch:** `broadcastWorldState()` body signature changed from
+  `DOMAIN_SEPARATORS.WORLD_STATE` to `DOMAIN_SEPARATORS.MESSAGE` to match the
+  `/peer/message` receiver verification.
+- **Ledger dead code:** Removed unused `LEDGER_DOMAIN` constant. Replaced fragile
+  string-splitting `LEDGER_SEPARATOR` construction with direct `PROTOCOL_VERSION` usage.
+- **Fastify reply:** Added explicit `return reply.send(body)` in `/peer/message` handler
+  to follow Fastify 5 async handler best practices.

--- a/packages/agent-world-sdk/src/peer-protocol.ts
+++ b/packages/agent-world-sdk/src/peer-protocol.ts
@@ -229,7 +229,7 @@ export function registerPeerRoutes(
         (body, statusCode) => {
           replied = true;
           if (statusCode) reply.code(statusCode);
-          reply.send(body);
+          return reply.send(body);
         }
       );
       if (!replied) return { ok: true };

--- a/packages/agent-world-sdk/src/world-ledger.ts
+++ b/packages/agent-world-sdk/src/world-ledger.ts
@@ -1,13 +1,13 @@
 import fs from "fs"
 import path from "path"
 import crypto from "node:crypto"
-import { signWithDomainSeparator, verifyWithDomainSeparator, DOMAIN_SEPARATORS } from "./crypto.js"
+import { signWithDomainSeparator, verifyWithDomainSeparator } from "./crypto.js"
 import type { Identity } from "./types.js"
 import type { LedgerEntry, LedgerEvent, AgentSummary, LedgerQueryOpts } from "./types.js"
+import { PROTOCOL_VERSION } from "./version.js"
 
 const ZERO_HASH = "0".repeat(64)
-const LEDGER_DOMAIN = `AgentWorld-Ledger-${DOMAIN_SEPARATORS.MESSAGE.split("-").slice(-1)[0].replace("\0", "")}`
-const LEDGER_SEPARATOR = `AgentWorld-Ledger-${DOMAIN_SEPARATORS.MESSAGE.split("-")[2]}`
+const LEDGER_SEPARATOR = `AgentWorld-Ledger-${PROTOCOL_VERSION}\0`
 
 /**
  * Append-only event ledger for World Agent activity.

--- a/packages/agent-world-sdk/src/world-server.ts
+++ b/packages/agent-world-sdk/src/world-server.ts
@@ -287,7 +287,7 @@ export async function createWorldServer(
       timestamp: Date.now(),
     };
     payload["signature"] = signWithDomainSeparator(
-      DOMAIN_SEPARATORS.WORLD_STATE,
+      DOMAIN_SEPARATORS.MESSAGE,
       payload,
       identity.secretKey
     );

--- a/test/key-rotation-sdk.test.mjs
+++ b/test/key-rotation-sdk.test.mjs
@@ -37,7 +37,27 @@ function makeProof(secretKey, signable) {
   }
 }
 
-function makeApp(t) {
+function makeSignedMessage(identity, overrides = {}) {
+  const payload = {
+    from: identity.agentId,
+    publicKey: identity.pubB64,
+    event: "chat",
+    content: { text: "hello" },
+    timestamp: Date.now(),
+    ...overrides,
+  }
+
+  return {
+    ...payload,
+    signature: signWithDomainSeparator(
+      DOMAIN_SEPARATORS.MESSAGE,
+      payload,
+      identity.secretKey
+    ),
+  }
+}
+
+function makeApp(t, opts = {}) {
   const fastify = Fastify({ logger: false })
   t.after(async () => {
     await fastify.close()
@@ -47,6 +67,7 @@ function makeApp(t) {
   registerPeerRoutes(fastify, {
     identity: makeIdentity(),
     peerDb,
+    ...opts,
   })
 
   return { fastify, peerDb }
@@ -142,4 +163,56 @@ test("sdk /peer/key-rotation accepts correctly bound rotations and persists the 
   assert.equal(response.statusCode, 200)
   assert.deepEqual(response.json(), { ok: true })
   assert.equal(peerDb.get(oldKey.agentId)?.publicKey, newKey.pubB64)
+})
+
+test("sdk /peer/message returns the callback response body on the happy path", async (t) => {
+  const sender = makeIdentity()
+  const { fastify, peerDb } = makeApp(t, {
+    onMessage: async (_agentId, event, content, reply) => {
+      reply({
+        ok: true,
+        event,
+        echoedContent: content,
+      })
+    },
+  })
+
+  const response = await fastify.inject({
+    method: "POST",
+    url: "/peer/message",
+    headers: { "content-type": "application/json" },
+    payload: makeSignedMessage(sender),
+  })
+
+  assert.equal(response.statusCode, 200)
+  assert.deepEqual(response.json(), {
+    ok: true,
+    event: "chat",
+    echoedContent: { text: "hello" },
+  })
+  assert.equal(peerDb.get(sender.agentId)?.publicKey, sender.pubB64)
+})
+
+test("sdk /peer/message preserves callback error replies", async (t) => {
+  const sender = makeIdentity()
+  const { fastify } = makeApp(t, {
+    onMessage: async (_agentId, _event, _content, reply) => {
+      reply({ error: "custom failure" }, 422)
+    },
+  })
+
+  const response = await fastify.inject({
+    method: "POST",
+    url: "/peer/message",
+    headers: { "content-type": "application/json" },
+    payload: makeSignedMessage(sender, {
+      event: "fail",
+      content: { reason: "test" },
+    }),
+  })
+
+  assert.equal(response.statusCode, 422)
+  assert.deepEqual(response.json(), {
+    error: "custom failure",
+  })
 })

--- a/test/world-ledger-separator.test.mjs
+++ b/test/world-ledger-separator.test.mjs
@@ -1,0 +1,41 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import { verifyWithDomainSeparator, DOMAIN_SEPARATORS } from "../packages/agent-world-sdk/dist/crypto.js"
+import { loadOrCreateIdentity } from "../packages/agent-world-sdk/dist/identity.js"
+import { PROTOCOL_VERSION } from "../packages/agent-world-sdk/dist/version.js"
+import { WorldLedger } from "../packages/agent-world-sdk/dist/world-ledger.js"
+
+describe("world ledger separator", () => {
+  it("uses the canonical versioned separator constant in the built SDK artifact", () => {
+    const worldLedgerPath = new URL("../packages/agent-world-sdk/dist/world-ledger.js", import.meta.url)
+    const worldLedgerSource = fs.readFileSync(worldLedgerPath, "utf8")
+    const expectedSeparatorDeclaration = `const LEDGER_SEPARATOR = \`AgentWorld-Ledger-\${PROTOCOL_VERSION}\\0\`;`
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ledger-separator-"))
+    const identity = loadOrCreateIdentity(dataDir, "separator-test")
+    const ledger = new WorldLedger(dataDir, "test-world", identity)
+    const [entry] = ledger.getEntries()
+    const { worldSig, ...sigPayload } = entry
+    const expectedSeparator = `AgentWorld-Ledger-${PROTOCOL_VERSION}\0`
+
+    try {
+      assert.ok(
+        worldLedgerSource.includes(expectedSeparatorDeclaration),
+        `expected ${worldLedgerPath.pathname} to contain ${expectedSeparatorDeclaration}`
+      )
+      assert.equal(expectedSeparator, `AgentWorld-Ledger-${PROTOCOL_VERSION}\0`)
+      assert.equal(
+        verifyWithDomainSeparator(expectedSeparator, identity.pubB64, sigPayload, worldSig),
+        true
+      )
+      assert.equal(
+        verifyWithDomainSeparator(DOMAIN_SEPARATORS.MESSAGE, identity.pubB64, sigPayload, worldSig),
+        false
+      )
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/world-state-broadcast.test.mjs
+++ b/test/world-state-broadcast.test.mjs
@@ -11,6 +11,7 @@ const {
   signWithDomainSeparator,
   DOMAIN_SEPARATORS,
   agentIdFromPublicKey,
+  verifyWithDomainSeparator,
 } = await import("../packages/agent-world-sdk/dist/crypto.js")
 
 const PORT = 18210
@@ -233,6 +234,26 @@ describe("World state broadcast delivery", () => {
       const content = JSON.parse(hit.body.content)
       assert.equal(content.worldId, "broadcast-test")
       assert.equal(content.tick, 1)
+
+      const { signature, ...unsignedPayload } = hit.body
+      assert.equal(
+        verifyWithDomainSeparator(
+          DOMAIN_SEPARATORS.MESSAGE,
+          hit.body.publicKey,
+          unsignedPayload,
+          signature
+        ),
+        true
+      )
+      assert.equal(
+        verifyWithDomainSeparator(
+          DOMAIN_SEPARATORS.WORLD_STATE,
+          hit.body.publicKey,
+          unsignedPayload,
+          signature
+        ),
+        false
+      )
     }
   })
 })


### PR DESCRIPTION
## BUG-4, BUG-5, BUG-6 [LOW] — Protocol consistency fixes

### BUG-4 — world.state body signature domain separator mismatch
Changed `broadcastWorldState()` from `DOMAIN_SEPARATORS.WORLD_STATE` to `MESSAGE`.

### BUG-5 — LEDGER_DOMAIN dead code + fragile LEDGER_SEPARATOR
Removed unused `LEDGER_DOMAIN`. Direct `PROTOCOL_VERSION` usage for separator.

### BUG-6 — Fastify async handler implicit undefined return
Explicit `return reply.send(body)` in `/peer/message` handler.

### Tests
- `test/world-ledger-separator.test.mjs` — separator constant correctness
- `test/key-rotation-sdk.test.mjs` — reply path coverage
- `test/world-state-broadcast.test.mjs` — body signing domain check

### Changeset
`fix-protocol-consistency.md` — `@resciencelab/agent-world-sdk` patch

### Stack
- ✅ PR #110 — Broadcast leak fix (merged)
- PR #114 — Key rotation validation
- PR #115 — Base58 codec fix
- **→ PR 4/4** (this) — Protocol consistency

**All 6 bugs fixed. Final: 181 tests, 0 failures ✅**