### PR TITLE
fix(ci): reference root package in changesets to fix Release workflow

### DIFF
--- a/.changeset/fix-base58-codec.md
+++ b/.changeset/fix-base58-codec.md
@@ -1,5 +1,5 @@
 ---
-"@resciencelab/agent-world-sdk": patch
+"@resciencelab/agent-world-network": patch
 ---
 
 fix(sdk): correct base58 encode/decode for leading-zero byte inputs

--- a/.changeset/fix-broadcast-leak.md
+++ b/.changeset/fix-broadcast-leak.md
@@ -1,5 +1,4 @@
 ---
-"@resciencelab/agent-world-sdk": patch
 "@resciencelab/agent-world-network": patch
 ---
 

--- a/.changeset/fix-key-rotation-validation.md
+++ b/.changeset/fix-key-rotation-validation.md
@@ -1,5 +1,5 @@
 ---
-"@resciencelab/agent-world-sdk": patch
+"@resciencelab/agent-world-network": patch
 ---
 
 fix(sdk): validate newAgentId matches newPublicKey in key rotation handler

--- a/.changeset/fix-protocol-consistency.md
+++ b/.changeset/fix-protocol-consistency.md
@@ -1,5 +1,5 @@
 ---
-"@resciencelab/agent-world-sdk": patch
+"@resciencelab/agent-world-network": patch
 ---
 
 fix(sdk): protocol consistency — domain separator, ledger constant, Fastify reply


### PR DESCRIPTION
## Problem

The Release CI workflow fails with:

```
Error: Found changeset fix-base58-codec for package @resciencelab/agent-world-sdk which is not in the workspace
```

The 4 changesets from the SDK bug fix PRs (#110, #114, #115, #116) referenced
`@resciencelab/agent-world-sdk`, but this package is not registered as an npm
workspace — only `@resciencelab/agent-world-network` (the root) is known to changesets.

## Fix

Updated all 4 changeset files to reference `@resciencelab/agent-world-network` instead:
- `fix-broadcast-leak.md`
- `fix-key-rotation-validation.md`
- `fix-base58-codec.md`
- `fix-protocol-consistency.md`