### PR TITLE
fix: Cloudflare DNS step error visibility and idempotency

### DIFF
--- a/.changeset/fix-gateway-dns-error-handling.md
+++ b/.changeset/fix-gateway-dns-error-handling.md
@@ -1,0 +1,5 @@
+---
+"@resciencelab/agent-world-network": patch
+---
+
+Fix deploy-gateway: remove -f from Cloudflare curl to expose API errors, skip DNS update when IP is already correct (idempotent with Elastic IP), downgrade Cloudflare API failures to warnings so deploys are not blocked.

--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -48,29 +48,37 @@ jobs:
           fi
           echo "EC2 public IP: $EC2_IP  Gateway: $GATEWAY_HOST"
 
-          EXISTING=$(curl -sf \
+          PAYLOAD="{\"type\":\"A\",\"name\":\"$GATEWAY_HOST\",\"content\":\"$EC2_IP\",\"ttl\":1,\"proxied\":true}"
+
+          EXISTING=$(curl -s \
             "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records?type=A&name=$GATEWAY_HOST" \
             -H "Authorization: Bearer $CF_API_TOKEN" \
             -H "Content-Type: application/json")
 
-          RECORD_ID=$(echo "$EXISTING" | jq -r '.result[0].id // empty')
-
-          PAYLOAD="{\"type\":\"A\",\"name\":\"$GATEWAY_HOST\",\"content\":\"$EC2_IP\",\"ttl\":1,\"proxied\":true}"
-
-          if [ -n "$RECORD_ID" ]; then
-            curl -sf -X PUT \
-              "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records/$RECORD_ID" \
-              -H "Authorization: Bearer $CF_API_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d "$PAYLOAD"
-            echo "Updated DNS A record $RECORD_ID → $EC2_IP"
+          if ! echo "$EXISTING" | jq -e '.success == true' > /dev/null 2>&1; then
+            echo "::warning::Cloudflare API error: $(echo "$EXISTING" | jq -rc '.errors // .')"
+            echo "Skipping DNS update — record may already be correct."
           else
-            curl -sf -X POST \
-              "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records" \
-              -H "Authorization: Bearer $CF_API_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d "$PAYLOAD"
-            echo "Created DNS A record $GATEWAY_HOST → $EC2_IP"
+            RECORD_ID=$(echo "$EXISTING" | jq -r '.result[0].id // empty')
+            CURRENT_IP=$(echo "$EXISTING" | jq -r '.result[0].content // empty')
+
+            if [ "$CURRENT_IP" = "$EC2_IP" ]; then
+              echo "DNS already up to date ($GATEWAY_HOST → $EC2_IP), skipping update."
+            elif [ -n "$RECORD_ID" ]; then
+              curl -s -X PUT \
+                "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records/$RECORD_ID" \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                -H "Content-Type: application/json" \
+                -d "$PAYLOAD" | jq -c '{success,errors}'
+              echo "Updated DNS A record $RECORD_ID → $EC2_IP"
+            else
+              curl -s -X POST \
+                "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records" \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                -H "Content-Type: application/json" \
+                -d "$PAYLOAD" | jq -c '{success,errors}'
+              echo "Created DNS A record $GATEWAY_HOST → $EC2_IP"
+            fi
           fi
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
## Problem

The `Update Cloudflare DNS` step fails with exit code 22 (curl `-f` flag silently discards the CF API error body), blocking every deploy on `main` push.

## Fix

- Remove `-f` from curl so Cloudflare API errors are visible in logs
- Check `success == true` in the API response; downgrade failures to `::warning::` so deploys are not blocked
- Skip the update when DNS already points to the correct IP (idempotent — important now that we have a static Elastic IP `3.19.212.2`)

Fixes the failure in https://github.com/ReScienceLab/agent-world-network/actions/runs/23424532421