### PR TITLE
fix: correct domain agentsworlds.ai → agentworlds.ai

### DIFF
--- a/.changeset/fix-correct-domain.md
+++ b/.changeset/fix-correct-domain.md
@@ -1,0 +1,5 @@
+---
+"@resciencelab/agent-world-network": patch
+---
+
+Fix domain: agentsworlds.ai -> agentworlds.ai across all config and source files.

--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       ECR_REPOSITORY: awn-gateway
       INSTANCE_ID: i-04670f4d1a72c7d5d
-      GATEWAY_URL: ${{ vars.GATEWAY_URL || 'https://gateway.agentsworlds.ai' }}
+      GATEWAY_URL: ${{ vars.GATEWAY_URL || 'https://gateway.agentworlds.ai' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
   <h2>Gateway Worlds</h2>
   <p class="muted">World Servers announce directly to the Gateway. The standalone <code>bootstrap.json</code> registry artifact was removed in this branch.</p>
   <div class="controls">
-    <input id="gateway-url" value="https://gateway.agentsworlds.ai" placeholder="https://gateway.example.com" aria-label="Gateway URL">
+    <input id="gateway-url" value="https://gateway.agentworlds.ai" placeholder="https://gateway.example.com" aria-label="Gateway URL">
     <button id="load-worlds" type="button">Load</button>
   </div>
   <table>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "agent-network"
   ],
   "gateway": {
-    "url": "https://gateway.agentsworlds.ai"
+    "url": "https://gateway.agentworlds.ai"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,7 +247,7 @@ function buildSendOpts(peerIdOrAddr?: string): SendOptions {
 }
 
 function getGatewayUrl(): string {
-  return (process.env.GATEWAY_URL ?? "https://gateway.agentsworlds.ai").replace(/\/+$/, "")
+  return (process.env.GATEWAY_URL ?? "https://gateway.agentworlds.ai").replace(/\/+$/, "")
 }
 
 async function fetchGatewayWorldRecord(worldId: string): Promise<{

--- a/web/client.js
+++ b/web/client.js
@@ -3,7 +3,7 @@
  * Polls the Gateway /worlds endpoint to discover live worlds on the AWN network.
  */
 
-const GATEWAY = window.GATEWAY_URL || "https://gateway.agentsworlds.ai";
+const GATEWAY = window.GATEWAY_URL || "https://gateway.agentworlds.ai";
 const POLL_INTERVAL = 15_000;
 
 const $statusDot = document.getElementById("status-dot");

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="style.css">
   <script>
     // Gateway URL — override if deployed separately
-    // window.GATEWAY_URL = "https://gateway.agentsworlds.ai"
+    // window.GATEWAY_URL = "https://gateway.agentworlds.ai"
   </script>
 </head>
 <body>


### PR DESCRIPTION
Fixes the domain typo throughout the codebase. The actual Cloudflare zone is `agentworlds.ai` (no 's'). Also updates the GitHub Actions `GATEWAY_URL` variable and propagates via sync-version.mjs.