### PR TITLE
fix: correct changeset package reference to workspace package

### DIFF
--- a/.changeset/fix-cross-version-sig-verify.md
+++ b/.changeset/fix-cross-version-sig-verify.md
@@ -1,5 +1,5 @@
 ---
-"@resciencelab/agent-world-sdk": patch
+"@resciencelab/agent-world-network": patch
 ---
 
 Fix cross-version HTTP signature verification: use sender's X-AgentWorld-Version header instead of local PROTOCOL_VERSION when reconstructing signing input, so gateway and peers running different SDK minor versions can still verify each other's signatures.


### PR DESCRIPTION
## Summary

The `fix-cross-version-sig-verify` changeset incorrectly referenced `@resciencelab/agent-world-sdk` which is not a workspace package recognized by changesets. This caused the release workflow (`changesets/action`) to fail with:

```
Error: Found changeset fix-cross-version-sig-verify for package @resciencelab/agent-world-sdk which is not in the workspace
```

Changed the package reference to `@resciencelab/agent-world-network` (the root workspace package).

Fixes the release workflow failure in https://github.com/ReScienceLab/agent-world-network/actions/runs/23527121322/job/68482839337